### PR TITLE
Fix No Warning Assertion on Plot Tests

### DIFF
--- a/tests/PlotsTest.m
+++ b/tests/PlotsTest.m
@@ -38,8 +38,7 @@ classdef PlotsTest < matlab.unittest.TestCase
             input.w = spectrum.w;
             input.powPerFreq = spectrum.S;
 
-            testHandle = @() WecOptTool.plot.powerPerFreq(input);
-            verifyWarningFree(testCase, testHandle)
+            WecOptTool.plot.powerPerFreq(input);
                               
         end
         
@@ -55,8 +54,7 @@ classdef PlotsTest < matlab.unittest.TestCase
                 input(i).powPerFreq = spectrum.S;
             end
             
-            testHandle = @() WecOptTool.plot.powerPerFreq(input);
-            verifyWarningFree(testCase, testHandle)
+            WecOptTool.plot.powerPerFreq(input);
                               
         end
         

--- a/tests/SeaStateTest.m
+++ b/tests/SeaStateTest.m
@@ -107,7 +107,7 @@ classdef SeaStateTest < matlab.unittest.TestCase
         end
         
         function testPlot(testCase)
-            verifyWarningFree(testCase, @() testCase.SS.plot())
+            testCase.SS.plot();
         end
         
         function testcheckSpectruMultiSeaStates(testCase)


### PR DESCRIPTION
## Description

If hardware support is not available on the testing platform then some plots may throw a warning so the verifywarningfree assertion has been removed from plot tests.

## Checklist:

- [x] Added the results of running the test suite (in pdf form)

[test_results.pdf](https://github.com/SNL-WaterPower/WecOptTool/files/5167966/test_results.pdf)

