### PR TITLE
Remove call to struct2array

### DIFF
--- a/examples/RM3/designDevice.m
+++ b/examples/RM3/designDevice.m
@@ -22,7 +22,8 @@ function hydro = getHydroScalar(lambda)
     [filepath, ~, ~] = fileparts(p);
     dataPath = fullfile(filepath, 'RM3_BEM.mat');
 
-    load(dataPath, 'hydro');
+    mf = matfile(dataPath);
+    hydro = mf.hydro;
 
     % dimensionalize w/ WEC-Sim built-in function
     hydro.rho = 1025;

--- a/examples/RM3/designDevice.m
+++ b/examples/RM3/designDevice.m
@@ -22,7 +22,7 @@ function hydro = getHydroScalar(lambda)
     [filepath, ~, ~] = fileparts(p);
     dataPath = fullfile(filepath, 'RM3_BEM.mat');
 
-    hydro = struct2array(load(dataPath, 'hydro'));
+    load(dataPath, 'hydro');
 
     % dimensionalize w/ WEC-Sim built-in function
     hydro.rho = 1025;


### PR DESCRIPTION
## Description

The function struct2array is undocumented and fails when the parallel toolbox is not installed

See the discussion [here](https://uk.mathworks.com/matlabcentral/answers/493612-any-fixes-for-undefined-function-or-variable-struct2array), for instance.

## Checklist:

- [x] Added the results of running the test suite (in pdf form)

[test_results_no_pct.pdf](https://github.com/SNL-WaterPower/WecOptTool/files/5238795/test_results_no_pct.pdf)

