### PR TITLE
Add external link to GitHub in TOC

### DIFF
--- a/docs/contents.rst
+++ b/docs/contents.rst
@@ -11,6 +11,7 @@
    user/references
 
 .. toctree::
+   :hidden:
    :caption: External
 
    GitHub Repository <https://github.com/SNL-WaterPower/WecOptTool>

--- a/docs/contents.rst
+++ b/docs/contents.rst
@@ -9,3 +9,8 @@
    user/api
    user/license
    user/references
+
+.. toctree::
+   :caption: External
+
+   GitHub Repository <https://github.com/SNL-WaterPower/WecOptTool>


### PR DESCRIPTION
## Description

This commit adds an external links TOCtree to the docs, currently for providing a quick link to the Github repo.
