### PR TITLE
Add note attribute to SeaState class

### DIFF
--- a/tests/SeaStateTest.m
+++ b/tests/SeaStateTest.m
@@ -52,6 +52,16 @@ classdef SeaStateTest < matlab.unittest.TestCase
     end
     
     methods(Test)
+        
+        function testNote(testCase)
+            
+            noteS.w = [1, 2, 3, 4]';
+            noteS.S = [0, 1, 2, 1]';
+            
+            noteSS = WecOptTool.SeaState(noteS);
+            verifyTrue(testCase, strcmp(noteSS.note, "Spectrum 1"));
+            
+        end
 
         function testSampleError(testCase)
             verifyTrue(testCase, all([testCase.SS.sampleError] == 0.01))
@@ -116,6 +126,17 @@ classdef SeaStateTest < matlab.unittest.TestCase
         
         function testPlot(testCase)
             testCase.SS.plot();
+        end
+        
+        function testPlotManual(testCase)
+            figure
+            hold on
+            grid on
+            arrayfun(@(x) plot(x.w,x.S,'DisplayName',x.note), testCase.SS)
+            legend()
+            xlim([0,3])
+            xlabel('Freq. [rad/s]')
+            ylabel('Spect. density [m^2 rad/s]')
         end
         
         function testcheckSpectruMultiSeaStates(testCase)

--- a/toolbox/+WecOptTool/SeaState.m
+++ b/toolbox/+WecOptTool/SeaState.m
@@ -17,6 +17,7 @@ classdef SeaState
     % given will be given a default upon instantiation of the object:
     %
     %     * mu
+    %     * note
     %
     % Arguments:
     %    S (struct):
@@ -71,7 +72,7 @@ classdef SeaState
     %     specificEnergy (float):
     %         the specific energy of the spectra [J / m\ :sup:`2`]
     %     mu (float): spectrum weighting, for arrays only  (defaults to 1)
-    %
+    %     note (string): a description of the spectrum
     %
     % --
     %
@@ -85,6 +86,7 @@ classdef SeaState
     %     trimLoss - error due to range trimming as percentage of max(S)
     %     specificEnergy - the specific energy of the spectra
     %     mu - spectrum weighting, for arrays only (defaults to 1)
+    %     note - a description of the spectrum
     %
     %  SeaState Methods:
     %    getAllFrequencies - return unique frequencies over all sea states
@@ -137,6 +139,7 @@ classdef SeaState
         S
         w
         mu
+        note
         baseS
         basew
         dw
@@ -185,6 +188,12 @@ classdef SeaState
 
                 if isfield(S, "mu")
                     obj(i).mu = S(i).mu;
+                end
+                
+                if isfield(S, "note")
+                    obj(i).note = S(i).note;
+                else
+                    obj(i).note = sprintf('Spectrum %d', i);
                 end
 
                 if isfield(options, "resampleByError") && ...


### PR DESCRIPTION
## Description

This commit adds the note attribute to the SeaState class to carry a description of each spectrum. This allows direct definition when initializing from WAFO for instance. If the note field is not set in the input struct then a default value is added.

A test was also added to check the plotting code shown in the RM3 optimization.m example in the online docs.

Fixes #186 

## Checklist:

- [x] Added the results of running the test suite (in pdf form)

[test_results.pdf](https://github.com/SNL-WaterPower/WecOptTool/files/5297898/test_results.pdf)

