### PR TITLE
Use MATLAB types in online documentation

### DIFF
--- a/toolbox/+WecOptTool/+base/NEMOH.m
+++ b/toolbox/+WecOptTool/+base/NEMOH.m
@@ -36,7 +36,7 @@ classdef NEMOH < handle
             % Determine if the NEMOH executables can be found.
             %
             % Returns:
-            %     bool: true if executables found, otherwise false.
+            %     logical: true if executables found, otherwise false.
             %
 
             startdir = pwd;

--- a/toolbox/+WecOptTool/+math/bisection.m
+++ b/toolbox/+WecOptTool/+math/bisection.m
@@ -2,14 +2,14 @@ function c = bisection(f, a, b, options)
     % Bisection method
     %
     % Args:
-    %   f (float): real valued function
-    %   a (float): search space lower boundary
-    %   b (float): search space upper boundary
-    %   tol (optional, float): solution tolerance, default = 1e-10
+    %   f (double): real valued function
+    %   a (double): search space lower boundary
+    %   b (double): search space upper boundary
+    %   tol (optional, double): solution tolerance, default = 1e-10
     %   nmax (optional, int): maximum number of operations, default = 1e4
     %
     % Returns:
-    %   float: root of f
+    %   double: root of f
     %
     % Note:
     %     The given interval boundaries must satisfy f(a) * f(b) <= 0

--- a/toolbox/+WecOptTool/+math/isClose.m
+++ b/toolbox/+WecOptTool/+math/isClose.m
@@ -3,13 +3,13 @@ function result = isClose(a, b, varargin)
     % exactly equal).
     %
     % Args:
-    %   a (float): first value to compare
-    %   b (float): second value to compare
-    %   rtol (float, optional): relative tolerence, default = 1e-05
-    %   atol (float, optional): absolute tolerance, default = 1e-08
+    %   a (double): first value to compare
+    %   b (double): second value to compare
+    %   rtol (double, optional): relative tolerence, default = 1e-05
+    %   atol (double, optional): absolute tolerance, default = 1e-08
     %
     % Returns:
-    %   bool: true if a is within given tolerances of b
+    %   logical: true if a is within given tolerances of b
     %
     % Note:
     %   Derived from the similar named `numpy routine

--- a/toolbox/+WecOptTool/+mesh/AxiMesh.m
+++ b/toolbox/+WecOptTool/+mesh/AxiMesh.m
@@ -8,9 +8,9 @@ classdef AxiMesh < WecOptTool.base.Mesher & WecOptTool.base.NEMOH
     %
     % Attributes:
     %     path (string): path to file storage folder
-    %     verb (bool): use verbose console outputs (default false)
-    %     rho (float): water density (default = 1025 kg/m\ :sup:`3`)
-    %     g (float):
+    %     verb (logical): use verbose console outputs (default false)
+    %     rho (double): water density (default = 1025 kg/m\ :sup:`3`)
+    %     g (double):
     %         gravitational acceleration (default = 9.81 m/s\ :sup:`2`)
     %
     % --
@@ -69,16 +69,16 @@ classdef AxiMesh < WecOptTool.base.Mesher & WecOptTool.base.NEMOH
             % symmetric in the xz plane.
             %
             % Arguments:
-            %   r (array of float): radial coordinates
-            %   z (array of float): vertical coordinates
-            %   ntheta (int):
+            %   r (array of double): radial coordinates
+            %   z (array of double): vertical coordinates
+            %   ntheta (int32):
             %       number of points for discretization in angular 
             %       direction (over pi radians)
-            %   nfobj (int):
+            %   nfobj (int32):
             %       number of nodes within the resulting half body mesh
-            %   zG (float):
+            %   zG (double):
             %       z-coordinate of the bodies centre of gravity
-            %   bodyNum (int):
+            %   bodyNum (int32):
             %       the number of the body (starting from one)
             %       
             % Returns:
@@ -87,12 +87,12 @@ classdef AxiMesh < WecOptTool.base.Mesher & WecOptTool.base.NEMOH
             %
             % ============  ================  ======================================
             % **Variable**  **Format**        **Description**
-            % bodyNum       int               body number
+            % bodyNum       int32             body number
             % name          char array        name of the mesh
             % nodes         Nx4 table         table of N node positions with columns ID, x, y, z
             % panels        Mx4 int32 array   array of M panels where each row contains the 4 connected node IDs
-            % xzSymmetric   bool              body is symmetric in xz plane (half mesh)
-            % zG            float             z-coordinate of the bodies centre of gravity
+            % xzSymmetric   logical           body is symmetric in xz plane (half mesh)
+            % zG            double            z-coordinate of the bodies centre of gravity
             % ============  ================  ======================================
             %
             % Warning:

--- a/toolbox/+WecOptTool/+plot/plotMesh.m
+++ b/toolbox/+WecOptTool/+plot/plotMesh.m
@@ -5,19 +5,19 @@ function plotMesh(meshses, newFig)
     %     meshses (struct):
     %         Struct array containing mesh description with fields as 
     %         described below
-    %     newFig (bool):
+    %     newFig (logical):
     %         If true a new figure is created
     %
     % The meshes struct must contain the following fields:
     %
     % ============  ================  ======================================
     % **Variable**  **Format**        **Description**
-    % bodyNum       int               body number
+    % bodyNum       int32             body number
     % name          char array        name of the mesh
     % nodes         Nx4 table         table of N node positions with columns ID, x, y, z
     % panels        Mx4 int32 array   array of M panels where each row contains the 4 connected node IDs
-    % xzSymmetric   bool              body is symmetric in xz plane (half mesh)
-    % zG            float             z-coordinate of the bodies centre of gravity
+    % xzSymmetric   logical           body is symmetric in xz plane (half mesh)
+    % zG            double            z-coordinate of the bodies centre of gravity
     % ============  ================  ======================================
     %
     

--- a/toolbox/+WecOptTool/+plot/powerPerFreq.m
+++ b/toolbox/+WecOptTool/+plot/powerPerFreq.m
@@ -7,8 +7,8 @@ function powerPerFreq(input)
     %
     % ============  ================  =====================================
     % **Variable**  **Format**        **Description**
-    % w             Nx1 float array   N sea-state frequencie
-    % powPerFreq    Nx1 float array   Power production per frequency
+    % w             Nx1 double array  N sea-state frequencie
+    % powPerFreq    Nx1 double array  Power production per frequency
     % ============  ================  =====================================
     %
     

--- a/toolbox/+WecOptTool/+solver/NEMOH.m
+++ b/toolbox/+WecOptTool/+solver/NEMOH.m
@@ -8,9 +8,9 @@ classdef NEMOH < WecOptTool.base.Solver & WecOptTool.base.NEMOH
     %
     % Attributes:
     %     path (string): path to file storage folder
-    %     verb (bool): use verbose console outputs (default false)
-    %     rho (float): water density (default = 1025 kg/m\ :sup:`3`)
-    %     g (float):
+    %     verb (logical): use verbose console outputs (default false)
+    %     rho (double): water density (default = 1025 kg/m\ :sup:`3`)
+    %     g (double):
     %         gravitational acceleration (default = 9.81 m/s\ :sup:`2`)
     %
     % --
@@ -116,7 +116,7 @@ classdef NEMOH < WecOptTool.base.Solver & WecOptTool.base.NEMOH
             %       represents a different body with body number given by 
             %       the ``bodyNum`` property. See table below for field
             %       definitions.
-            %   w (array of float):
+            %   w (array of double):
             %       The angular wave frequencies to be calculated.
             %       
             % Returns:
@@ -127,11 +127,11 @@ classdef NEMOH < WecOptTool.base.Solver & WecOptTool.base.NEMOH
             %
             % ============  ================  ======================================
             % **Variable**  **Format**        **Description**
-            % bodyNum       int               body number
+            % bodyNum       int32             body number
             % name          char array        name of the mesh
             % nodes         Nx4 table         table of N node positions with columns ID, x, y, z
             % panels        Mx4 int32 array   array of M panels where each row contains the 4 connected node IDs
-            % zG            float             z-coordinate of the bodies centre of gravity
+            % zG            double            z-coordinate of the bodies centre of gravity
             % ============  ================  ======================================
             % 
             % Note:

--- a/toolbox/+WecOptTool/+system/getFolders.m
+++ b/toolbox/+WecOptTool/+system/getFolders.m
@@ -9,7 +9,7 @@ function folderNames = getFolders(baseFolder, varargin)
     %
     % The following options are supported:
     %
-    %   absPath (bool):
+    %   absPath (logical):
     %     If true, the absolute path to the folders is returned. Defaults
     %     to false.
     %

--- a/toolbox/+WecOptTool/+system/hasToolbox.m
+++ b/toolbox/+WecOptTool/+system/hasToolbox.m
@@ -11,9 +11,9 @@ function [combined, licensed, installed] = hasToolbox(licenseName,  ...
     % Returns:
     %     (): outputs are:
     %     
-    %         combined (bool): true if toolbox is licensed and installed
-    %         licensed (bool): true is toolbox is licensed
-    %         installed (bool): true is toolbox is installed
+    %         combined (logical): true if toolbox is licensed and installed
+    %         licensed (logical): true is toolbox is licensed
+    %         installed (logical): true is toolbox is installed
     %
     
     % Copyright 2020 National Technology & Engineering Solutions of Sandia, 

--- a/toolbox/+WecOptTool/AutoFolder.m
+++ b/toolbox/+WecOptTool/AutoFolder.m
@@ -79,7 +79,7 @@ classdef AutoFolder < WecOptTool.base.TempFolder
             %   variableName (string): variable to recover
             %
             % Returns:
-            %   cell:
+            %   cell array:
             %       cell array containing all stored version of given
             %       variable name
             %

--- a/toolbox/+WecOptTool/Hydrodynamics.m
+++ b/toolbox/+WecOptTool/Hydrodynamics.m
@@ -40,29 +40,29 @@ classdef Hydrodynamics
     % Attributes:
     %    base (struct):
     %        copy of the input struct
-    %    ex (array):
+    %    ex (array of double):
     %        complex excitation force or torque ([6*Nb,Nh,Nf])
-    %    g (float):
+    %    g (double):
     %        gravitational acceleration
-    %    rho (float):
+    %    rho (double):
     %        water density
-    %    w (array):
+    %    w (array of double):
     %        simulated wave frequencies ([1,Nf])
-    %    A (array):
+    %    A (array of double):
     %        radiation added mass ([6*Nb,6*Nb,Nf])
-    %    Ainf (array):
+    %    Ainf (array of double):
     %        infinite frequency added mass ([6*Nb,6*Nb])
-    %    B (array):
+    %    B (array of double):
     %        radiation wave damping ([6*Nb,6*Nb,Nf])
-    %    C (array):
+    %    C (array of double):
     %        hydrostatic restoring stiffness ([6,6,Nb])
-    %    Nb (int):
+    %    Nb (int32):
     %        number of bodies
-    %    Nh (int):
+    %    Nh (int32):
     %        number of wave headings
-    %    Nf (int):
+    %    Nf (int32):
     %        number of wave frequencies
-    %    Vo (array):
+    %    Vo (array of double):
     %        displaced volume ([1,Nb])
     %    solverName (string):
     %        name of solver used to generate hydrodyamic parameters.

--- a/toolbox/+WecOptTool/SeaState.m
+++ b/toolbox/+WecOptTool/SeaState.m
@@ -27,16 +27,16 @@ classdef SeaState
     %
     % The following options are supported:
     %
-    %    resampleByError (float):
+    %    resampleByError (double):
     %        Resample the given spectra such that the error with respect
     %        to the original spectral density is less than the given
     %        percentage of the maximum spectral density (per spectrum).
-    %    resampleByStep (float):
+    %    resampleByStep (double):
     %        Resample the spectra with the given angular frequency step.
-    %    trimFrequencies (float):
+    %    trimFrequencies (double):
     %        Remove frequencies with spectral density less than the
     %        given percentage of the maximum (per spectrum).
-    %    extendFrequencies (int):
+    %    extendFrequencies (int32):
     %        Add addition frequencies such that the largest value is
     %        extendFrequencies times the maximum (i.e. max(w)).
     %
@@ -59,19 +59,19 @@ classdef SeaState
     %
     %
     % Attributes:
-    %     S (array of float): spectral density [m\ :sup:`2` s/rad]
-    %     w (array of float): angular frequency [rad / s]
-    %     baseS (array of float):
+    %     S (array of double): spectral density [m\ :sup:`2` s/rad]
+    %     w (array of double): angular frequency [rad / s]
+    %     baseS (array of double):
     %         unmodified spectral density [m\ :sup:`2` s/rad]
-    %     basew (array of float): unmodified angular frequency [rad / s]
-    %     dw (float): angular frequency step [rad / s]
-    %     sampleError (float): 
+    %     basew (array of double): unmodified angular frequency [rad / s]
+    %     dw (double): angular frequency step [rad / s]
+    %     sampleError (double): 
     %         maximum sampling error as percentage of max(S) 
-    %     trimLoss (float):
+    %     trimLoss (double):
     %         error due to range trimming as percentage of max(S)
-    %     specificEnergy (float):
+    %     specificEnergy (double):
     %         the specific energy of the spectra [J / m\ :sup:`2`]
-    %     mu (float): spectrum weighting, for arrays only  (defaults to 1)
+    %     mu (double): spectrum weighting, for arrays only  (defaults to 1)
     %     note (string): a description of the spectrum
     %
     % --
@@ -244,7 +244,8 @@ classdef SeaState
             % Returns all unique frequencies over all sea states
             %
             % Returns:
-            %     array: sorted unique angular frequencies [rad / s]
+            %     array of double:
+            %         sorted unique angular frequencies [rad / s]
             
             allFreqs = [];
             
@@ -261,10 +262,10 @@ classdef SeaState
             % at the given step size
             %
             % Arguments:
-            %     dw (float): angular frequency step
+            %     dw (double): angular frequency step
             %
             % Returns:
-            %     array: regular angular frequencies [rad / s]
+            %     array of double: regular angular frequencies [rad / s]
             
             arguments
                 obj
@@ -290,7 +291,7 @@ classdef SeaState
             % Get wave amplitude per angular frequency
             %
             % Returns:
-            %     array: wave amplitudes [m]
+            %     array of double: wave amplitudes [m]
             
             Aw = sqrt(2 * obj.dw * obj.S(:));
             
@@ -567,14 +568,15 @@ classdef SeaState
             %
             % The following options are supported:
             %
-            %    g (optional, float):
+            %    g (optional, double):
             %        Acceleration due to gravity, default = 9.81 
             %        m/s\ :sup:`2`.
-            %    rho (optional, float):
+            %    rho (optional, double):
             %        Water density, default 1028 kg/m\ :sup:`3`.
             %
             % Returns:
-            %     array: specify energy per spectra [J / m\ :sup:`2`]
+            %     array of double:
+            %         specify energy per spectra [J / m\ :sup:`2`]
             %
             % Example:
             %
@@ -616,7 +618,8 @@ classdef SeaState
             %        :mat:meth:`+WecOptTool.SeaState.checkSpectrum`
             %
             % Returns:
-            %     array: absolute error per spectrum [m\ :sup:`2` s/rad]
+            %     array of double:
+            %         absolute error per spectrum [m\ :sup:`2` s/rad]
             %
             % Example:
             %     Find the maximum absolute error in spectral density
@@ -671,7 +674,7 @@ classdef SeaState
             %        :mat:meth:`+WecOptTool.SeaState.checkSpectrum`
             %
             % Returns:
-            %     array: relative error per spectrum
+            %     array of double: relative error per spectrum
             %
             % Example:
             %     Find the relative error in specific energy of a spectrum 
@@ -711,7 +714,7 @@ classdef SeaState
             %         struct array that satisfies the
             %         :mat:meth:`+WecOptTool.SeaState.checkSpectrum` 
             %         method
-            %     densityTolerence (float):
+            %     densityTolerence (double):
             %         Percentage of maximum spectral density
             %
             % Returns:
@@ -754,7 +757,7 @@ classdef SeaState
             %         struct array that satisfies the
             %         :mat:meth:`+WecOptTool.SeaState.checkSpectrum` 
             %         method
-            %     nRepeats (int):
+            %     nRepeats (int32):
             %         Number of repetitions of max frequency
             %
             % Returns:
@@ -806,16 +809,16 @@ classdef SeaState
             %         struct array that satisfies the
             %         :mat:meth:`+WecOptTool.SeaState.checkSpectrum` 
             %         method
-            %     targetError (float):
+            %     targetError (double):
             %         Target maximum error in normalized spectral density 
-            %     min_dw (optional, float):
+            %     min_dw (optional, double):
             %         Smallest frequency step to test, default = 1e-4
             %
             % Returns:
             %      :
             %     - S (struct): Sea state struct which conforms to 
             %       :mat:meth:`+WecOptTool.SeaState.checkSpectrum`
-            %     - dw (array): Frequency spacings per spectrum
+            %     - dw (array of double): Frequency spacings per spectrum
             %
             % Example:
             %     Resample such that the maximum absolute error in 
@@ -872,15 +875,15 @@ classdef SeaState
             %         struct array that satisfies the
             %         :mat:meth:`+WecOptTool.SeaState.checkSpectrum` 
             %         method
-            %     dw (float):
+            %     dw (double):
             %         Angular frequency step size
             %
             % Returns:
             %      :
             %     - S (struct): Sea state struct which conforms to 
             %       :mat:meth:`+WecOptTool.SeaState.checkSpectrum`
-            %     - errors (array): error in spectral density (normalized 
-            %       by the maximum) per spectrum
+            %     - errors (array of double): error in spectral density 
+            %       (normalized by the maximum) per spectrum
             %
             % Example:
             %     Resample using a fixed angular frequency step of 0.2
@@ -963,8 +966,8 @@ classdef SeaState
             % Returns a regular wave using a WAFO-like struct
             %
             % Arguments:
-            %     w (array): frequency vector
-            %     sdata (array):
+            %     w (array of double): frequency vector
+            %     sdata (array of double):
             %         [A, T], where A is the amplitude and T is the period
             %
             % Returns:

--- a/toolbox/+WecOptTool/mesh.m
+++ b/toolbox/+WecOptTool/mesh.m
@@ -21,12 +21,12 @@ function mesh = mesh(meshName, folder, varargin)
     %
     % ============  ================  ======================================
     % **Variable**  **Format**        **Description**
-    % bodyNum       int               body number
+    % bodyNum       int32             body number
     % name          char array        name of the mesh
     % nodes         Nx4 table         table of N node positions with columns ID, x, y, z
     % panels        Mx4 int32 array   array of M panels where each row contains the 4 connected node IDs
-    % xzSymmetric   bool              body is symmetric in xz plane (half mesh)
-    % zG            float             z-coordinate of the bodies centre of gravity
+    % xzSymmetric   logical           body is symmetric in xz plane (half mesh)
+    % zG            double            z-coordinate of the bodies centre of gravity
     % ============  ================  ======================================
     %
     % --


### PR DESCRIPTION
## Description

This commit changes any Python style types used in the online documentation to MATLAB types. Examples include float to double, bool to logical and int to int32.

