### PR TITLE
Ensure random phases are selected from range [0, 2pi]

### DIFF
--- a/examples/RM3/simulateDevice.m
+++ b/examples/RM3/simulateDevice.m
@@ -201,7 +201,7 @@ function out = pseudoSpectralControl(motion,        ...
     
     % Add phase realizations
     n_ph_avg = 5;
-    ph_mat = [dynModel.ph, rand(length(dynModel.w), n_ph_avg-1) * 2 * pi];
+    ph_mat = [motion.ph, rand(length(motion.w), n_ph_avg-1) * 2 * pi];
     n_ph = size(ph_mat, 2);
     
     freq = motion.W;

--- a/examples/RM3/simulateDevice.m
+++ b/examples/RM3/simulateDevice.m
@@ -68,7 +68,7 @@ function dynamic = getDynamicModel(static, hydro, S)
     waveAmp = sqrt(2 * dw * s);
 
     % Row vector of random phases?
-    ph = rand(length(s), 1);
+    ph = rand(length(s), 1) * 2 * pi;
 
     % Wave height in frequency domain
     eta_fd = waveAmp .* exp(1i*ph);

--- a/examples/RM3/simulateDevice.m
+++ b/examples/RM3/simulateDevice.m
@@ -201,7 +201,7 @@ function out = pseudoSpectralControl(motion,        ...
     
     % Add phase realizations
     n_ph_avg = 5;
-    ph_mat = 2 * pi * rand(length(motion.w), n_ph_avg); 
+    ph_mat = [dynModel.ph, rand(length(dynModel.w), n_ph_avg-1) * 2 * pi];
     n_ph = size(ph_mat, 2);
     
     freq = motion.W;

--- a/examples/WaveBot/simulateDevice.m
+++ b/examples/WaveBot/simulateDevice.m
@@ -226,7 +226,7 @@ function myPerf = psControl(dynModel,delta_Zmax,delta_Fmax)
     
     % Add phase realizations
     n_ph = 5;
-    ph_mat = [dynModel.ph rand(length(dynModel.w), n_ph-1) * 2 * pi];
+    ph_mat = [dynModel.ph, rand(length(dynModel.w), n_ph-1) * 2 * pi];
 
     for ind_ph = 1 : n_ph
         

--- a/examples/WaveBot/simulateDevice.m
+++ b/examples/WaveBot/simulateDevice.m
@@ -83,7 +83,7 @@ function dynModel = getDynamicsModel(hydro, SS, interpMethod)
     waveAmp = interp1(SS.w, waveAmpSS, w, interpMethod, 'extrap');
 
     % Row vector of random phases
-    ph = rand(size(waveAmp));
+    ph = rand(size(waveAmp)) * 2 * pi;
 
     % Wave height in frequency domain
     eta_fd = waveAmp .* exp(1i * ph);
@@ -226,7 +226,7 @@ function myPerf = psControl(dynModel,delta_Zmax,delta_Fmax)
     
     % Add phase realizations
     n_ph = 5;
-    ph_mat = [dynModel.ph, rand(length(dynModel.w), n_ph-1)];
+    ph_mat = [dynModel.ph rand(length(dynModel.w), n_ph-1) * 2 * pi];
 
     for ind_ph = 1 : n_ph
         


### PR DESCRIPTION
## Description

In the RM3 and WaveBot examples, random phases used in the calculations were selected from the range [0, 1] when they should be selected from [0, 2pi].

Fixes #200 
