### PR TITLE
Continuous time post-processing

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,19 @@
 
 # Changelog
 
+## Version 1.0.2
+
+**Major Changes**
+
+*
+
+**Bug fixes**
+
+*
+
+**New features**
+
+* Create continuous time functions from the WEC dynamics and PTO pseudo-spectral results.
 
 ## Version 1.0.1
 


### PR DESCRIPTION
## Description
Modify the post-processing (both WEC.solve solutions and PTO) to return the time domain results at different points (i.e. more points than the collocation. Or return continuous function.  

## Type of PR
- [ ] Bug fix
- [ ] Major change
- [x] New feature

## Checklist for PR
- [x] Authors read the [contribution guidelines](https://github.com/SNL-WaterPower/WecOptTool/blob/main/.github/CONTRIBUTING.md)
- [x] The pull request is from an issue branch (not main) on your fork to the [main branch in WecOptTool](https://github.com/SNL-WaterPower/WecOptTool). 
- [x] The authors have given the admins edit access
- [x] All changes adhere to the style guide including PEP8, Docstrings, and Type Hints.
- [x] Added note in [Changelog](https://github.com/SNL-WaterPower/WecOptTool/blob/main/CHANGES.md)
- [ ] Modified the documentation if applicable
- [ ] Modified or added a new test
- [x] All tests pass
- [ ] Documentation builds
- [ ] [Reference or close any relevant issues](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)

## Additional details
The Fourier series is discrete frequency continuous time. So no need to restrict time domain results to the collocation points.
