### PR TITLE
x scale logging

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,9 @@
 ## Version 1.0.3
 
 * minor updates to README
-* logging of decision vector and objective function controlled entirely via logging package config
+* logging of decision vector and objective function 
+  * controlled entirely via logging package config
+  * move to `info` logging level (`debug` gives too much from other packages, e.g., matplotlib)
 
 **Bug fixes**
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 ## Version 1.0.3
 
 * minor updates to README
+* logging of decision vector and objective function controlled entirely via logging package config
 
 ## Version 1.0.2
 

--- a/docs/source/theory.rst
+++ b/docs/source/theory.rst
@@ -92,6 +92,7 @@ For a wave tank scale device, one might expect velocities of :math:`\mathcal{O}(
 For larger WECs, this discrepancy in the orders of magnitude may be even worse.
 Scaling mismatches in the decision variable :math:`x` and with the objective function :math:`J(x)` can lead to problems with convergence.
 To alleviate this issue, WecOptTool allows users to set scale factors for the components of :math:`x` as well as the objective function (see :meth:`core.WEC.solve`).
+Additionally, you may set :code:`import logging, logging.basicConfig(level=logging.INFO)` to output the mean values of `x` and the objective function during the solution process.
 
 Constraints
 ^^^^^^^^^^^

--- a/wecopttool/core.py
+++ b/wecopttool/core.py
@@ -585,7 +585,6 @@ class WEC:
               optim_options: dict[str, Any] = {},
               use_grad: bool = True,
               maximize: bool = False,
-              scale_logging: bool = False,
               ) -> tuple[xr.Dataset, xr.Dataset, np.ndarray, np.ndarray, float,
                          optimize.optimize.OptimizeResult]:
         """Solve the WEC co-design problem.
@@ -631,11 +630,6 @@ class WEC:
         maximize: bool
             Whether to maximize the objective function. The default is
             ``False`` to minimize the objective function.
-        scale_logging: bool
-            If true, print the value of the decision variable (decomposed into
-            x_wec and x_opt) and objective function at each solver iteration.
-            Useful for setting ``scale_x_wec``, scale_x_opt``, and
-            ``scale_obj``. The default is `False``.
 
         Returns
         -------
@@ -721,8 +715,7 @@ class WEC:
                 + f"{np.abs(np.mean(x_opt)):.2e}, " \
                 + f"{np.abs(obj_fun_scaled(x)):.2e}]")
         
-        if scale_logging:
-            problem['callback'] = callback
+        problem['callback'] = callback
 
         if use_grad:
             problem['jac'] = grad(obj_fun_scaled)

--- a/wecopttool/core.py
+++ b/wecopttool/core.py
@@ -716,9 +716,9 @@ class WEC:
 
         def callback(x):
             x_wec, x_opt = self.decompose_decision_var(x)
-                + f"[{np.abs(np.mean(x_wec)):.2e}" \
-                + f"{np.abs(np.mean(x_opt)):.2e}" \
             log.info("[mean(x_wec), mean(x_opt), obj_fun(x)]: " \
+                + f"[{np.abs(np.mean(x_wec)):.2e}, " \
+                + f"{np.abs(np.mean(x_opt)):.2e}, " \
                 + f"{np.abs(obj_fun_scaled(x)):.2e}]")
         
         if scale_logging:

--- a/wecopttool/core.py
+++ b/wecopttool/core.py
@@ -716,9 +716,9 @@ class WEC:
 
         def callback(x):
             x_wec, x_opt = self.decompose_decision_var(x)
-            log.debug("[mean(x_wec), mean(x_opt), obj_fun(x)]: " \
                 + f"[{np.abs(np.mean(x_wec)):.2e}" \
                 + f"{np.abs(np.mean(x_opt)):.2e}" \
+            log.info("[mean(x_wec), mean(x_opt), obj_fun(x)]: " \
                 + f"{np.abs(obj_fun_scaled(x)):.2e}]")
         
         if scale_logging:


### PR DESCRIPTION
## Description
Update the x scale logging

- control entirely via `logging` configuration (set to `INFO`
- missing commas

## Type of PR
- [x] Bug fix
- [ ] Major change
- [ ] New feature

## Checklist for PR
- [x] Authors read the [contribution guidelines](https://github.com/SNL-WaterPower/WecOptTool/blob/main/.github/CONTRIBUTING.md)
- [x] The pull request is from an issue branch (not main) on your fork to the [main branch in WecOptTool](https://github.com/SNL-WaterPower/WecOptTool). 
- [x] The authors have given the admins edit access
- [x] All changes adhere to the style guide including PEP8, Docstrings, and Type Hints.
- [x] Added note in [Changelog](https://github.com/SNL-WaterPower/WecOptTool/blob/main/CHANGES.md)
- [x] Modified the documentation if applicable
- [ ] Modified or added a new test
- [ ] All tests pass
- [ ] Documentation builds
- [ ] [Reference or close any relevant issues](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
