### PR TITLE
Wave direction subset

### DIFF
--- a/tests/test_wecopttool.py
+++ b/tests/test_wecopttool.py
@@ -24,6 +24,9 @@ def _wec():
     f0 = 0.05
     nfreq = 18
 
+    #wave directions
+    wave_dirs = [0, 10, 20]
+
     #  mesh
     meshfile = os.path.join(os.path.dirname(__file__), 'data', 'wavebot.stl')
 
@@ -42,7 +45,7 @@ def _wec():
     wec = wot.WEC(fb, mass, stiffness, f0, nfreq, rho=rho)
 
     # BEM
-    wec.run_bem()
+    wec.run_bem(wave_dirs)
 
     return wec
 

--- a/tests/test_wecopttool.py
+++ b/tests/test_wecopttool.py
@@ -775,3 +775,24 @@ def test_solve_callback(wec, regular_wave, pto, capfd):
     out, err = capfd.readouterr()
 
     assert out.split('\n')[0] == cbstring
+
+
+def test_regular_wave_power(wec, regular_wave, pto):
+    """Confirm that regular wave power solver results 
+    equals the theoretical power"""
+    wec.constraints = []
+    obj_fun = pto.average_power
+    _, wec_fdom, _, _, obj, _ = wec.solve(regular_wave, obj_fun, 
+                                            nstate_opt = pto.nstate,
+                                            scale_x_wec = 1.0,
+                                            scale_x_opt = 0.01,
+                                            scale_obj = 1e-1,
+                                            optim_options={})
+
+    sol_analytic = -1*np.sum(np.abs(wec_fdom['excitation_force'][1:, :])**2 
+                            / (8*np.real(wec.hydro.Zi[:, 0, 0])))
+    print('Analytic sol sum', np.sum(sol_analytic))
+    print('Solver sol', obj)
+    #relative tolerance for assertion
+    rtol = 0.005
+    assert np.isclose(sol_analytic,obj,rtol)

--- a/tests/test_wecopttool.py
+++ b/tests/test_wecopttool.py
@@ -791,8 +791,6 @@ def test_regular_wave_power(wec, regular_wave, pto):
 
     sol_analytic = -1*np.sum(np.abs(wec_fdom['excitation_force'][1:, :])**2 
                             / (8*np.real(wec.hydro.Zi[:, 0, 0])))
-    print('Analytic sol sum', np.sum(sol_analytic))
-    print('Solver sol', obj)
     #relative tolerance for assertion
     rtol = 0.005
-    assert np.isclose(sol_analytic,obj,rtol)
+    assert np.isclose(sol_analytic, obj, rtol)

--- a/wecopttool/core.py
+++ b/wecopttool/core.py
@@ -995,8 +995,8 @@ def wave_excitation(bem_data: xr.Dataset, waves: xr.Dataset
     """
     assert np.allclose(waves['omega'].values, bem_data['omega'].values)
 
-    w_dir_subset, w_indx = subsetclose(waves['wave_direction'].values
-        ,bem_data['wave_direction'].values)
+    w_dir_subset, w_indx = subsetclose(waves['wave_direction'].values, 
+                bem_data['wave_direction'].values)
     
     if not w_dir_subset:
         raise ValueError(

--- a/wecopttool/core.py
+++ b/wecopttool/core.py
@@ -1346,15 +1346,47 @@ def _degrees_to_radians(degrees: float | npt.ArrayLike
     radians = radians.item() if (radians.size == 1) else np.sort(radians)
     return radians
 
-def subsetclose(A, B, rtol=1.e-5, atol=1.e-8, equal_nan=False):
+def subsetclose(subset_a: float | npt.ArrayLike, 
+                set_b: float | npt.ArrayLike,
+                rtol: float = 1.e-5, atol:float = 1.e-8, 
+                equal_nan: bool = False) -> tuple[bool, list]:
     """
-    Returns True if the first array is element-wise equal within a tolerance
-    to a subset of the second array.
-    Returns the indices the elements of the first array at the locations
-    of the second array
+    Compare if two arrays are subset equal within a tolerance.
+
+
+    Parameters
+    ----------
+    subset_a: float | npt.ArrayLike
+        First array which is tested for being subset.
+    set_b: float | npt.ArrayLike
+        Second array which is tested for containing subset_a.
+    rtol: float
+        The relative tolerance parameter.
+    atol: float
+        The absolute tolerance parameter.
+    equal_nan: bool
+        Whether to compare NaNs as equal.
+
+    Returns
+    -------
+    result: bool
+        boolean if the entire first array is a subset of second array 
+    ind: list
+        List with integer indices:
+        Where the first array's elements 
+        are located inside the second array.
     """
-    ind = [(list(B).index(b)) for b in B for a in A \
-        if np.isclose(a, b, rtol, atol, equal_nan)]
-    result = all(any(np.isclose(a, b, rtol, atol, equal_nan) \
-        for b in B) for a in A)
+    assert len(set(subset_a)) == len(subset_a), "Elements in subset_a not unique"
+    assert len(set(set_b)) == len(set_b), "Elements in set_b not unique"
+
+    ind = []
+    tmp_result = [False for i in range(len(subset_a))]
+    for subset_element in subset_a:
+        for set_element in set_b:
+            if np.isclose(subset_element, set_element, rtol, atol, equal_nan):
+                tmp_set_ind = np.where(np.isclose(set_element, set_b , rtol, atol, equal_nan))
+                tmp_subset_ind = np.where(np.isclose(subset_element, subset_a , rtol, atol, equal_nan))
+                ind.append( int(tmp_set_ind[0]) )
+                tmp_result[ int(tmp_subset_ind[0]) ] = True
+    result = all(tmp_result)
     return(result, ind)

--- a/wecopttool/core.py
+++ b/wecopttool/core.py
@@ -993,8 +993,9 @@ def wave_excitation(bem_data: xr.Dataset, waves: xr.Dataset
     time_dom: xarray.Dataset
         Time domain wave excitation and elevation.
     """
-    assert np.allclose(waves['omega'].values, bem_data['omega'].values)
-
+    if not np.allclose(waves['omega'].values, bem_data['omega'].values):
+        raise ValueError("Wave and BEM frequencies do not match")
+        
     w_dir_subset, w_indx = subsetclose(waves['wave_direction'].values, 
                 bem_data['wave_direction'].values)
     

--- a/wecopttool/core.py
+++ b/wecopttool/core.py
@@ -1000,10 +1000,11 @@ def wave_excitation(bem_data: xr.Dataset, waves: xr.Dataset
     
     if not w_dir_subset:
         raise ValueError(
-            f"Wave direction(s): "\
-            f" {(np.rad2deg(waves['wave_direction'].values))} (degree)"\
-            f" not in BEM solution: "\
-            f" {np.rad2deg(bem_data['wave_direction'].values)} (degree).")
+            "Some wave directions are not in BEM solution " +
+            "\n Wave direction(s):" +
+            f"{(np.rad2deg(waves['wave_direction'].values))} (deg)" +
+            " \n BEM directions: " +
+            f"{np.rad2deg(bem_data['wave_direction'].values)} (deg).")
 
     # excitation BEM
     exc_coeff = bem_data['Froude_Krylov_force'] + \

--- a/wecopttool/core.py
+++ b/wecopttool/core.py
@@ -1372,13 +1372,13 @@ def subsetclose(subset_a: float | npt.ArrayLike,
     Returns
     -------
     result: bool
-        boolean if the entire first array is a subset of second array 
+        Boolean if the entire first array is a subset of second array 
     ind: list
-        List with integer indices:
-        Where the first array's elements 
+        List with integer indices where the first array's elements 
         are located inside the second array.
     """
-    assert len(set(subset_a)) == len(subset_a), "Elements in subset_a not unique"
+    assert len(set(subset_a)) == len(subset_a
+                                     ), "Elements in subset_a not unique"
     assert len(set(set_b)) == len(set_b), "Elements in set_b not unique"
 
     ind = []
@@ -1386,8 +1386,11 @@ def subsetclose(subset_a: float | npt.ArrayLike,
     for subset_element in subset_a:
         for set_element in set_b:
             if np.isclose(subset_element, set_element, rtol, atol, equal_nan):
-                tmp_set_ind = np.where(np.isclose(set_element, set_b , rtol, atol, equal_nan))
-                tmp_subset_ind = np.where(np.isclose(subset_element, subset_a , rtol, atol, equal_nan))
+                tmp_set_ind = np.where(
+                    np.isclose(set_element, set_b , rtol, atol, equal_nan))
+                tmp_subset_ind = np.where(
+                    np.isclose(subset_element, subset_a , rtol, atol, 
+                               equal_nan))
                 ind.append( int(tmp_set_ind[0]) )
                 tmp_result[ int(tmp_subset_ind[0]) ] = True
     result = all(tmp_result)

--- a/wecopttool/waves.py
+++ b/wecopttool/waves.py
@@ -94,6 +94,11 @@ def regular_wave(f0: float, nfreq: int, freq: float, amplitude: float,
      xr.Dataset
         Wave dataset.
     """
+    # check that only a single direction is given
+    if len(np.atleast_1d(np.array(direction).squeeze())) != 1:
+         raise ValueError("Regular waves need to originate from " +
+                          " single incident wave direction")
+
     # empty dataset
     waves = wave_dataset(f0, nfreq, direction)
 


### PR DESCRIPTION
## Description
This is the same as the previous pull request that was cancelled #83 .
Implemented a new function `subsetclose()` which checks if an entire array `isclose()` to a subset in a second array and returns the indices of the respective entries from the second array. This function is used to check if the directions in `waves` are available in the BEM solution. Next only the right wave direction dimensions of the BEM solution are picked to create the `wave_excitation()`. This enables the appropriate excitation force coefficients for the multidirectional waves. This resolves issues #80, #81 and #82 

## Type of PR
- [x] Bug fix
- [ ] Major change
- [x] New feature

## Checklist for PR
- [x] Authors read the [contribution guidelines](https://github.com/SNL-WaterPower/WecOptTool/blob/main/.github/CONTRIBUTING.md)
- [x] The pull request is from an issue branch (not main) on your fork to the [main branch in WecOptTool](https://github.com/SNL-WaterPower/WecOptTool). 
- [x] The authors have given the admins edit access
- [x] All changes adhere to the style guide including PEP8, Docstrings, and Type Hints.
- [x] Added note in [Changelog](https://github.com/SNL-WaterPower/WecOptTool/blob/main/CHANGES.md)
- [ ] Modified the documentation if applicable
- [ ] Modified or added a new test
- [x] All tests pass
- [x] Documentation builds
- [x] [Reference or close any relevant issues](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)

## Additional details
Include any relevant context and describe any validation and verification efforts.
