### PR TITLE
Minor typographic edits in documentation and  examples

### DIFF
--- a/docs/source/theory.rst
+++ b/docs/source/theory.rst
@@ -88,7 +88,7 @@ Scaling
 For many WEC problems, :eq:`optim_prob` will be poorly scaled.
 Recall that :math:`x = [x_{w}, x_{u}]`, where :math:`x_{w}` describes the state of the WEC (e.g., velocities) and :math:`x_{u}` is a vector to be optimized to maximize power absorption.
 Consider, for example, a general case without a controller structure, in which :math:`x_{u}` would relate to PTO forces.
-For a wave tank scale device, one might expect velocities of :math:`\mathcal{O}(1e-1)`, but the forces could be :math:`\mathcal{O}(1e3)`.
+For a wave tank scale device, one might expect velocities of :math:`\mathcal{O}(1e{-1})`, but the forces could be :math:`\mathcal{O}(1e3)`.
 For larger WECs, this discrepancy in the orders of magnitude may be even worse.
 Scaling mismatches in the decision variable :math:`x` and with the objective function :math:`J(x)` can lead to problems with convergence.
 To alleviate this issue, WecOptTool allows users to set scale factors for the components of :math:`x` as well as the objective function (see :meth:`wecopttool.core.WEC.solve`).

--- a/examples/tutorial_1_wavebot.ipynb
+++ b/examples/tutorial_1_wavebot.ipynb
@@ -226,7 +226,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Next we will create the constraints, which must be in the correct format for [`scipy.optimize.minimize()`](https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html). \n",
+    "Next we will create the constraints, which must be in the correct format for `scipy.optimize.minimize()` ([docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html)). \n",
     "We will constraint the PTO force to 2000 N in either direction. \n",
     "We will enforce the constraint at 4 times more points than the dynamics (see theory section for why this is helpful for the pseudo-spectral problem). \n",
     "This will be the only constraint.\n",

--- a/examples/tutorial_1_wavebot.ipynb
+++ b/examples/tutorial_1_wavebot.ipynb
@@ -158,8 +158,7 @@
    "metadata": {},
    "source": [
     "Next we will add the mass and hydrostatic properties. \n",
-    "If these values are known they can be added directly. H\n",
-    "Here we will use the fact that the WaveBot is free floating and assume constant density to calculate these properties. \n",
+    "If these values are known they can be added directly. Here we will use the fact that the WaveBot is free floating and assume constant density to calculate these properties. \n",
     "Capytaine does not (yet) natively perform hydrostatic calculations. \n",
     "We can use `meshmagick` to do this, which has been wrapped for convenience in `wecopttool.hydrostatics`. "
    ]

--- a/examples/tutorial_1_wavebot.ipynb
+++ b/examples/tutorial_1_wavebot.ipynb
@@ -64,7 +64,7 @@
     "### WEC object\n",
     "In this section we will create the `WEC` object, which contains all the information about the WEC and its dynamics.\n",
     "This includes the mesh, degrees of freedom, mass and hydrostatic properties, linear hydrodynamic coefficients (from a BEM solution), additional dynamic forces (e.g. PTO force, mooring, non-linear hydrodynamics), and constraints (e.g. maximum PTO extension). \n",
-    "In this case, the only additional force will be the PTO force and the only constraint will be a maximum PTO force of $2000 N$.\n",
+    "In this case, the only additional force will be the PTO force and the only constraint will be a maximum PTO force of 2000 N.\n",
     "Note that the BEM solution is not required when creating the WEC object, it can be calculated or read after the WEC is created.\n",
     "WecOptTool uses Capytaine as a BEM solver, and one of the first things we will do is create a Capytaine FloatingBody. \n",
     "\n",
@@ -227,7 +227,7 @@
    "metadata": {},
    "source": [
     "Next we will create the constraints, which must be in the correct format for [`scipy.optimize.minimize()`](https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html). \n",
-    "We will constraint the PTO force to $2000 N$ in either direction. \n",
+    "We will constraint the PTO force to 2000 N in either direction. \n",
     "We will enforce the constraint at 4 times more points than the dynamics (see theory section for why this is helpful for the pseudo-spectral problem). \n",
     "This will be the only constraint.\n",
     "\n",
@@ -538,7 +538,7 @@
    "metadata": {},
    "source": [
     "## Solve\n",
-    "Now we can solve for the optimal PTO force, subject to the dynamics and our additional constraint (no more than $2000 N$ force). \n",
+    "Now we can solve for the optimal PTO force, subject to the dynamics and our additional constraint (no more than 2000 N force). \n",
     "WecOptTool will solve the optimization problem (PTO force that will produce the highest average power) while simultaneously ensuring the dynamics equation is satisfied.  \n",
     "\n",
     "To help the optimization we will scale the problem before solving it (see Documentation). \n",
@@ -698,7 +698,7 @@
     "We will first look at some time-domain solutions. \n",
     "We will only plot a subset of the available quantities; inspect the `xarray.Dataset` objects for all stored quantities. \n",
     "\n",
-    "Note that the PTO force never exceeds $2000N$, and that due to the non-linear constraint the WEC heave motion is not sinusoidal. "
+    "Note that the PTO force never exceeds 2000 N, and that due to the non-linear constraint the WEC heave motion is not sinusoidal. "
    ]
   },
   {
@@ -952,7 +952,7 @@
     "\n",
     "We will look at comparisons in both the time- and frequency-domain. \n",
     "Note that the optimal constrained PTO force follows the optimal unconstrained solution (sinusoidal) whenever the unconstrained solution is within the constraint. \n",
-    "When the constraint is active the optimal PTO force is the maximum PTO force of $2000 N$. \n",
+    "When the constraint is active the optimal PTO force is the maximum PTO force of 2000 N. \n",
     "Also note that the unconstrained optimal PTO force uses only one component at the excitation frequency, while the optimal constrained solution also contains components at odd multiples of the excitation frequency. "
    ]
   },


### PR DESCRIPTION
## Description
There are a number of minor typographic improvements in the documentation and examples. There are no changes the code itself in the examples.

## Type of PR
- [x] Bug fix
- [ ] Major change
- [ ] New feature

## Checklist for PR
- [x] Authors read the [contribution guidelines](https://github.com/SNL-WaterPower/WecOptTool/blob/main/.github/CONTRIBUTING.md)
- [x] The pull request is from an issue branch (not main) on your fork to the [main branch in WecOptTool](https://github.com/SNL-WaterPower/WecOptTool). 
- [x] The authors have given the admins edit access
- [x] All changes adhere to the style guide including PEP8, Docstrings, and Type Hints.
- [ ] Added note in [Changelog](https://github.com/SNL-WaterPower/WecOptTool/blob/main/CHANGES.md)
- [x] Modified the documentation if applicable
- [ ] Modified or added a new test
- [x] All tests pass
- [x] Documentation builds
- [x] [Reference or close any relevant issues](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
