### PR TITLE
Remove sine component of 2-point wave

### DIFF
--- a/examples/tutorial_1_wavebot.ipynb
+++ b/examples/tutorial_1_wavebot.ipynb
@@ -278,11 +278,14 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "### Objective function\n",
-    "The objective function is the quantity (scalar) we want to optimize—in this case, the average mechanical power. The objective function is itself a function of the optimization state, the size of which we need to properly define our call to `scipy.optimize.minimize()`. The average mechanical power can be taken directly from the `PTO` object we created:"
+    "The objective function is the quantity (scalar) we want to optimize—in this case, the average mechanical power. The objective function is itself a function of the optimization state, the size of which we need to properly define our call to `scipy.optimize.minimize()`. The average mechanical power can be taken directly from the `PTO` object we created.\n",
+    "\n",
+    "One technical quirk here: `nstate_opt` is one smaller than would be expected for a state space representing the mean (DC) component and the real and imaginary Fourier coefficients. This is because WecOptTool excludes the imaginary Fourier component of the highest frequency (the 2-point wave). Since the 2-point wave is sampled at multiples of $\\pi$, the imaginary component is evaluated as $sin(n\\pi); n = 0, 1, 2, ..., n_{freq}$, which is always zero. Excluding this component speeds up the optimization as the state space is reduced by one."
    ]
   },
   {
@@ -292,7 +295,7 @@
    "outputs": [],
    "source": [
     "obj_fun = pto.mechanical_average_power\n",
-    "nstate_opt = 2*nfreq+1"
+    "nstate_opt = 2*nfreq"
    ]
   },
   {
@@ -774,7 +777,7 @@
     "\n",
     "    # Objective function\n",
     "    obj_fun = pto.average_power\n",
-    "    nstate_opt = 2*nfreq+1\n",
+    "    nstate_opt = 2*nfreq\n",
     "    \n",
     "    # Solve\n",
     "    scale_x_wec = 1e1  \n",
@@ -855,7 +858,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": ".venv",
+   "display_name": "wot_dev",
    "language": "python",
    "name": "python3"
   },
@@ -869,11 +872,11 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13 (main, May 21 2022, 02:36:14) \n[Clang 13.0.0 (clang-1300.0.29.30)]"
+   "version": "3.10.8"
   },
   "vscode": {
    "interpreter": {
-    "hash": "723f21f66e8d0a61fa50c731a2afd8116b597a052ef38afbfcb36e5a5e841e22"
+    "hash": "a3e13d9eb6391ec8c830b5b864d7e2cac256aef786c5e95ba02dc5258710976f"
    }
   }
  },

--- a/examples/tutorial_2_AquaHarmonics.ipynb
+++ b/examples/tutorial_2_AquaHarmonics.ipynb
@@ -348,7 +348,7 @@
     "gear_ratio_generator = gear_ratios['R21']/radii['S3']\n",
     "kinematics = gear_ratio_generator*np.eye(ndof)\n",
     "controller = None\n",
-    "nstate_opt = 2*nfreq + 1\n",
+    "nstate_opt = 2*nfreq\n",
     "pto_impedance = None\n",
     "pto = wot.pto.PTO(\n",
     "    ndof, kinematics, controller, pto_impedance, power_loss, name\n",
@@ -944,7 +944,7 @@
   },
   "vscode": {
    "interpreter": {
-    "hash": "caaaf143527b32ca1d6056ca65c73bf8275eb7b562f39aa0b7adcbdad499fc32"
+    "hash": "a3e13d9eb6391ec8c830b5b864d7e2cac256aef786c5e95ba02dc5258710976f"
    }
   }
  },

--- a/examples/tutorial_2_AquaHarmonics.ipynb
+++ b/examples/tutorial_2_AquaHarmonics.ipynb
@@ -348,7 +348,7 @@
     "gear_ratio_generator = gear_ratios['R21']/radii['S3']\n",
     "kinematics = gear_ratio_generator*np.eye(ndof)\n",
     "controller = None\n",
-    "nstate_opt = 2*nfreq\n",
+    "nstate_opt = 2*nfreq + 1\n",
     "pto_impedance = None\n",
     "pto = wot.pto.PTO(\n",
     "    ndof, kinematics, controller, pto_impedance, power_loss, name\n",
@@ -377,7 +377,7 @@
    "outputs": [],
    "source": [
     "def f_buoyancy(wec, x_wec, x_opt, waves, nsubsteps=1):\n",
-    "    \"\"\"Only the zero-th order component (doesn't include linear stiffness\"\"\"\n",
+    "    \"\"\"Only the zeroth order component (doesn't include linear stiffness)\"\"\"\n",
     "    return displacement * rho * g * np.ones([wec.ncomponents*nsubsteps, wec.ndof])\n",
     "\n",
     "def f_gravity(wec, x_wec, x_opt, waves, nsubsteps=1):\n",
@@ -596,7 +596,7 @@
    "source": [
     "### Post-process and plotting\n",
     "Next, we post-process the results to allow us to more easily visualize them in a series of plots.\n",
-    "Note that because the `WEC` and `PTO` objects are distinct (the WEC object really only knows what the force from the PTO is, not how how that force is obtained), we create two separate results objects (in each case, we get results in the frequency domain and time domain)."
+    "Note that because the `WEC` and `PTO` objects are distinct (the WEC object really only knows what the force from the PTO is, not how that force is obtained), we create two separate results objects (in each case, we get results in the frequency domain and time domain)."
    ]
   },
   {
@@ -764,13 +764,13 @@
     "**How big of an effect does the mass vs. line pre-tension have on the output power?** \n",
     "\n",
     "To do this study we will define the maximum mass as the mass that results in the pre-tension being equal to the minimum pretension, and define that as a mass ratio of `1`.\n",
-    "Note that this maximum mass is slightly smaller than the displaced mass, in order to maintain some positive net buoyancy and thus acheive the minimum line tension.\n",
+    "Note that this maximum mass is slightly smaller than the displaced mass, in order to maintain some positive net buoyancy and thus achieve the minimum line tension.\n",
     "We will then consider different designs consisting of different mass ratios and see how the output power varies. \n",
     "For each design the optimal controller for that design will be found (as in [Part 1](#1.-Optimal-control-with-a-loss-map))\n",
     "\n",
     "### Problem setup\n",
     "The first step is to create a function that encapsulates solving for the optimal control trajectory to maximize power (i.e., [Part 1](#1.-Optimal-control-with-a-loss-map) of this tutorial) as an inner loop nested within an outer loop that varies the mass ratio.\n",
-    "To accomplish this, we will create a function which takes the the mass fraction as an input and returns the average electrical power as an output.\n",
+    "To accomplish this, we will create a function which takes the mass fraction as an input and returns the average electrical power as an output.\n",
     "We consider the same regular wave operational condition as in [Part 1](#1.-Optimal-control-with-a-loss-map). "
    ]
   },

--- a/examples/tutorial_2_AquaHarmonics.ipynb
+++ b/examples/tutorial_2_AquaHarmonics.ipynb
@@ -348,7 +348,7 @@
     "gear_ratio_generator = gear_ratios['R21']/radii['S3']\n",
     "kinematics = gear_ratio_generator*np.eye(ndof)\n",
     "controller = None\n",
-    "nstate_opt = 2*nfreq + 1\n",
+    "nstate_opt = 2*nfreq\n",
     "pto_impedance = None\n",
     "pto = wot.pto.PTO(\n",
     "    ndof, kinematics, controller, pto_impedance, power_loss, name\n",

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -736,14 +736,14 @@ class TestFDToTDToFD:
         """Test the :python:`fd_to_td` function outputs when using FFT.
         """
         calculated = wot.fd_to_td(fd)
-        assert calculated.shape==(2*nfreq+1, 2) and np.allclose(calculated, td)
+        assert calculated.shape==(2*nfreq, 2) and np.allclose(calculated, td)
 
     def test_fd_to_td_1dof(self, fd_1dof, td_1dof, f1, nfreq):
         """Test the :python:`fd_to_td` function outputs for the 1 DOF
         case.
         """
         calculated = wot.fd_to_td(fd_1dof, f1, nfreq)
-        shape = (2*nfreq+1, 1)
+        shape = (2*nfreq, 1)
         calc_flat = calculated.squeeze()
         assert calculated.shape==shape and np.allclose(calc_flat, td_1dof)
 
@@ -761,7 +761,7 @@ class TestFDToTDToFD:
         for the 1 DOF.
         """
         calculated = wot.fd_to_td(fd_1dof)
-        shape = (2*nfreq+1, 1)
+        shape = (2*nfreq, 1)
         calc_flat = calculated.squeeze()
         assert calculated.shape==shape and np.allclose(calc_flat, td_1dof)
 
@@ -898,7 +898,7 @@ class TestForceFromImpedanceOrTransferFunction:
     @pytest.fixture(scope="class")
     def x_wec(self,):
         """WEC position state vector for a simple synthetic case."""
-        return [0, 1, 1, 1, 1, 0, 2, 2, 2]
+        return [0, 1, 1, 1, 0, 2, 2, 2]
 
     @pytest.fixture(scope="class")
     def force(self, f1, nfreq_imp, ndof_imp):
@@ -906,8 +906,8 @@ class TestForceFromImpedanceOrTransferFunction:
         # amplitude: A  = mimo @ x_wec, calculated manually
         #   reshaped for convenience
         A = np.array([
-            [0, 1,  7, 38, 50],
-            [0, 4, 10, 71, 83],
+            [0, 1,  7, 44],
+            [0, 4, 10, 77],
         ])
         force = np.zeros((wot.ncomponents(nfreq_imp), ndof_imp))
         w = wot.frequency(f1, nfreq_imp) * 2*np.pi
@@ -1341,7 +1341,7 @@ class TestDecomposeState:
     def test_function(self,):
         """Test that the function returns expected results."""
         ndof, nfreq = 1, 2  # ncomponents = ndof*(2*nfreq-1)+1 = 4
-        state = [1, 1, 1, 1, 1, 3.4]
+        state = [1, 1, 1, 1, 3.4]
         x_wec = [1, 1, 1, 1]
         x_opt = [3.4]
         x_w_calc, x_o_calc = wot.decompose_state(state, ndof, nfreq)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -418,7 +418,7 @@ class TestTimeMat:
         """Test the components at time zero of the time matrix with
         sub-steps.
         """
-        assert all(time_mat_sub[0, 1:]==np.array([1, 0]*nfreq)[:-1])
+        assert all(time_mat_sub[0, 1:]==np.array([1, 0]*(nfreq-1)))
 
     def test_behavior(self,):
         """Test that when the time matrix multiplies a state-vector it
@@ -428,7 +428,7 @@ class TestTimeMat:
         w = 2*np.pi*f
         time_mat = wot.time_mat(f, 1)
         x = 1.2 + 3.4j
-        X = np.reshape([0, np.real(x), np.imag(x)], [-1,1])[:-1]
+        X = np.concatenate([0, np.real(x), np.imag(x[:-1])])
         x_t = time_mat @ X
         t = wot.time(f, 1)
         assert np.allclose(x_t.squeeze(), np.real(x*np.exp(1j*w*t)))
@@ -491,7 +491,8 @@ class TestDerivativeMat:
         ])
         V = derivative_mat @ X
         v = np.sum(V[1::2]) + 1j*np.sum(V[2::2])
-        expected = np.sum([[(i+1) * 1j * w * x[i]] for i in range(np.size(x)-1)])
+        expected = np.sum(
+            [[(i+1) * 1j * w * x[i]] for i in range(np.size(x)-1)])
         assert np.allclose(v, expected)
 
 
@@ -521,7 +522,9 @@ class TestMIMOTransferMat:
                       3.5+4.5j])
         F = np.concatenate([
             [0.],
-            np.reshape([[np.real(z[i]*x[i]), np.imag(z[i]*x[i])] for i in range(np.size(x)-1)], -1),
+            np.reshape(
+                [[np.real(z[i]*x[i]), np.imag(z[i]*x[i])] for 
+                i in range(np.size(x)-1)], -1),
             [np.real(z[-1]) * np.real(x[-1])],
         ])
         Z_mimo = wot.mimo_transfer_mat(np.reshape([z], [1,1,-1]), False)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -38,7 +38,7 @@ def nsubsteps():
 @pytest.fixture(scope="module")
 def ncomponents(nfreq):
     """Number of components in the WEC state."""
-    return wot.ncomponents(nfreq, full_2pt_wave=True)
+    return wot.ncomponents(nfreq)
 
 
 @pytest.fixture(scope='module')
@@ -223,7 +223,7 @@ def mimo(nfreq_imp):
     """Correct MIMO matrix corresponding to the synthetic impedance
     matrix.
     """
-    ncomponents = wot.ncomponents(nfreq_imp, full_2pt_wave=True)
+    ncomponents = wot.ncomponents(nfreq_imp)
     mimo = np.zeros([ncomponents*2, ncomponents*2])
     mimo[:ncomponents, :ncomponents] = np.array([
         [0, 0,  0, 0,  0],
@@ -266,7 +266,7 @@ class TestNComponents:
 
     def test_nozero(self, nfreq):
         """Test without a zero-frequency component."""
-        assert wot.ncomponents(nfreq, False, full_2pt_wave=True) == 2*nfreq
+        assert wot.ncomponents(nfreq, False) == 2*nfreq
 
 
 class TestFrequency:
@@ -398,11 +398,11 @@ class TestTimeMat:
     @pytest.fixture(scope="class")
     def time_mat_sub(self, f1, nfreq, nsubsteps):
         """Time matrix with sub-steps."""
-        return wot.time_mat(f1, nfreq, nsubsteps, full_2pt_wave=True)
+        return wot.time_mat(f1, nfreq, nsubsteps)
 
     def test_time_mat(self, time_mat, f1_tm, nfreq_tm):
         """Test the default created time matrix."""
-        calculated = wot.time_mat(f1_tm, nfreq_tm, full_2pt_wave=True)
+        calculated = wot.time_mat(f1_tm, nfreq_tm)
         assert calculated==approx(time_mat)
 
     def test_shape(self, time_mat_sub, ncomponents, nsubsteps):
@@ -427,7 +427,7 @@ class TestTimeMat:
         """
         f = 0.1
         w = 2*np.pi*f
-        time_mat = wot.time_mat(f, 1, full_2pt_wave=True)
+        time_mat = wot.time_mat(f, 1)
         x = 1.2 + 3.4j
         X = np.reshape([0, np.real(x), np.imag(x)], [-1,1])
         x_t = time_mat @ X
@@ -467,12 +467,12 @@ class TestDerivativeMat:
 
     def test_derivative_mat(self, derivative_mat, f1_dm, nfreq_dm):
         """Test the default created derivative matrix."""
-        calculated = wot.derivative_mat(f1_dm, nfreq_dm, full_2pt_wave=True)
+        calculated = wot.derivative_mat(f1_dm, nfreq_dm)
         assert calculated==approx(derivative_mat)
 
     def test_no_mean(self, derivative_mat, f1_dm, nfreq_dm):
         """Test the derivative matrix without the mean component."""
-        calculated = wot.derivative_mat(f1_dm, nfreq_dm, False, full_2pt_wave=True)
+        calculated = wot.derivative_mat(f1_dm, nfreq_dm, False)
         assert calculated==approx(derivative_mat[1:, 1:])
 
     def test_behavior(self,):
@@ -482,7 +482,7 @@ class TestDerivativeMat:
         """
         f = 0.1
         w = 2*np.pi*f
-        derivative_mat = wot.derivative_mat(f, 1, full_2pt_wave=True)
+        derivative_mat = wot.derivative_mat(f, 1)
         x = 1.2 + 3.4j
         X = np.reshape([0, np.real(x), np.imag(x)], [-1,1])
         V = derivative_mat @ X
@@ -496,7 +496,7 @@ class TestMIMOTransferMat:
     def test_mimo_transfer_mat(self, impedance, mimo):
         """Test the function produces the correct MIMO transfer matrix.
         """
-        calculated = wot.mimo_transfer_mat(impedance, False, full_2pt_wave=True)
+        calculated = wot.mimo_transfer_mat(impedance, False)
         assert np.all(calculated == mimo)
 
     def test_behavior(self,):
@@ -510,7 +510,7 @@ class TestMIMOTransferMat:
         z = 2.1+4.3j
         f = z*x
         F = np.reshape([0, np.real(f), np.imag(f)], [-1,1])
-        Z_mimo = wot.mimo_transfer_mat(np.reshape([z], [1,1,-1]), False, full_2pt_wave=True)
+        Z_mimo = wot.mimo_transfer_mat(np.reshape([z], [1,1,-1]), False)
         assert np.allclose(Z_mimo @ X, F)
 
 
@@ -611,30 +611,30 @@ class TestRealToComplexToReal:
 
     def test_complex_to_real(self, complex_response, real_response):
         """Test converting from complex to real."""
-        calculated = wot.complex_to_real(complex_response, full_2pt_wave=True)
+        calculated = wot.complex_to_real(complex_response)
         assert np.allclose(calculated, real_response)
 
     def test_real_to_complex(self, complex_response, real_response):
         """Test converting from real to complex."""
-        calculated = wot.real_to_complex(real_response, full_2pt_wave=True)
+        calculated = wot.real_to_complex(real_response)
         assert np.allclose(calculated, complex_response)
 
     def test_cycle_real(self, real_response):
         """Test converting from real to complex and back to real."""
-        calculated = wot.real_to_complex(real_response, full_2pt_wave=True)
-        calculated = wot.complex_to_real(calculated, full_2pt_wave=True)
+        calculated = wot.real_to_complex(real_response)
+        calculated = wot.complex_to_real(calculated)
         assert np.allclose(calculated, real_response)
 
     def test_cycle_complex(self, complex_response):
         """Test converting from complex to real and back to complex."""
-        calculated = wot.complex_to_real(complex_response, full_2pt_wave=True)
-        calculated = wot.real_to_complex(calculated, full_2pt_wave=True)
+        calculated = wot.complex_to_real(complex_response)
+        calculated = wot.real_to_complex(calculated)
         assert np.allclose(calculated, complex_response)
 
     def test_shapes(self, complex_response, real_response):
         """Test output shapes."""
-        c_calc = wot.real_to_complex(real_response, full_2pt_wave=True)
-        r_calc = wot.complex_to_real(c_calc, full_2pt_wave=True)
+        c_calc = wot.real_to_complex(real_response)
+        r_calc = wot.complex_to_real(c_calc)
         c_shape = complex_response.shape
         r_shape = real_response.shape
         assert (c_calc.shape==c_shape) and (r_calc.shape==r_shape)
@@ -644,7 +644,7 @@ class TestRealToComplexToReal:
         input.
         """
         complex_1d = np.array([1+0j, 2+3j])
-        real_1d_calculated = wot.complex_to_real(complex_1d, full_2pt_wave=True)
+        real_1d_calculated = wot.complex_to_real(complex_1d)
         real_1d = np.array([[1], [2], [3]])
         assert np.allclose(real_1d_calculated, real_1d)
 
@@ -711,7 +711,7 @@ class TestFDToTDToFD:
 
     def test_fd_to_td(self, fd, td, f1, nfreq):
         """Test the :python:`fd_to_td` function outputs."""
-        calculated = wot.fd_to_td(fd, f1, nfreq, full_2pt_wave=True)
+        calculated = wot.fd_to_td(fd, f1, nfreq)
         assert calculated.shape==(2*nfreq+1, 2) and np.allclose(calculated, td)
 
     def test_td_to_fd(self, fd, td, f1, nfreq):
@@ -722,14 +722,14 @@ class TestFDToTDToFD:
     def test_fft(self, fd, td, nfreq):
         """Test the :python:`fd_to_td` function outputs when using FFT.
         """
-        calculated = wot.fd_to_td(fd, full_2pt_wave=True)
+        calculated = wot.fd_to_td(fd)
         assert calculated.shape==(2*nfreq+1, 2) and np.allclose(calculated, td)
 
     def test_fd_to_td_1dof(self, fd_1dof, td_1dof, f1, nfreq):
         """Test the :python:`fd_to_td` function outputs for the 1 DOF
         case.
         """
-        calculated = wot.fd_to_td(fd_1dof, f1, nfreq, full_2pt_wave=True)
+        calculated = wot.fd_to_td(fd_1dof, f1, nfreq)
         shape = (2*nfreq+1, 1)
         calc_flat = calculated.squeeze()
         assert calculated.shape==shape and np.allclose(calc_flat, td_1dof)
@@ -747,7 +747,7 @@ class TestFDToTDToFD:
         """Test the :python:`fd_to_td` function outputs when using FFT
         for the 1 DOF.
         """
-        calculated = wot.fd_to_td(fd_1dof, full_2pt_wave=True)
+        calculated = wot.fd_to_td(fd_1dof)
         shape = (2*nfreq+1, 1)
         calc_flat = calculated.squeeze()
         assert calculated.shape==shape and np.allclose(calc_flat, td_1dof)
@@ -896,7 +896,7 @@ class TestForceFromImpedanceOrTransferFunction:
             [0, 1,  7, 38, 50],
             [0, 4, 10, 71, 83],
         ])
-        force = np.zeros((wot.ncomponents(nfreq_imp, full_2pt_wave=True), ndof_imp))
+        force = np.zeros((wot.ncomponents(nfreq_imp), ndof_imp))
         w = wot.frequency(f1, nfreq_imp) * 2*np.pi
         t = wot.time(f1, nfreq_imp)
         force[:, 0] = (
@@ -943,7 +943,7 @@ class TestForceFromWaves:
         """Test regular wave forces."""
         # correct
         A = fexc_regular
-        force = np.zeros((wot.ncomponents(nfreq, full_2pt_wave=True), ndof_waves))
+        force = np.zeros((wot.ncomponents(nfreq), ndof_waves))
         w = wot.frequency(f1, nfreq) * 2*np.pi
         w = w[1:]
         t = wot.time(f1, nfreq)
@@ -965,7 +965,7 @@ class TestForceFromWaves:
         """Test iregular wave forces."""
         # correct
         A = fexc_multi
-        force = np.zeros((wot.ncomponents(nfreq, full_2pt_wave=True), ndof_waves))
+        force = np.zeros((wot.ncomponents(nfreq), ndof_waves))
         w = wot.frequency(f1, nfreq) * 2*np.pi
         w = w[1:]
         t = wot.time(f1, nfreq)
@@ -1029,7 +1029,7 @@ class TestInertiaStandardForces:
         forces = wot.standard_forces(data)
         # calculated inertia and forces
         wec = wot.WEC(
-            f1, nfreq, {}, inertia_matrix=data['inertia_matrix'].values, full_2pt_wave=True)
+            f1, nfreq, {}, inertia_matrix=data['inertia_matrix'].values)
         waves = wot.waves.regular_wave(
             f1, nfreq, wave_freq, wave_amp, wave_phase_deg)
         x_wec = np.zeros((nfreq*2+1)*ndof)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -262,11 +262,11 @@ class TestNComponents:
     def test_default(self, ncomponents, nfreq):
         """Test default, which will include a zero-frequency component.
         """
-        assert ncomponents == 2*nfreq + 1
+        assert ncomponents == 2*nfreq
 
     def test_nozero(self, nfreq):
         """Test without a zero-frequency component."""
-        assert wot.ncomponents(nfreq, False) == 2*nfreq
+        assert wot.ncomponents(nfreq, False) == 2*nfreq - 1
 
 
 class TestFrequency:
@@ -712,7 +712,7 @@ class TestFDToTDToFD:
     def test_fd_to_td(self, fd, td, f1, nfreq):
         """Test the :python:`fd_to_td` function outputs."""
         calculated = wot.fd_to_td(fd, f1, nfreq)
-        assert calculated.shape==(1+2*nfreq, 2) and np.allclose(calculated, td)
+        assert calculated.shape==(2*nfreq, 2) and np.allclose(calculated, td)
 
     def test_td_to_fd(self, fd, td, f1, nfreq):
         """Test the :python:`td_to_fd` function outputs."""
@@ -723,14 +723,14 @@ class TestFDToTDToFD:
         """Test the :python:`fd_to_td` function outputs when using FFT.
         """
         calculated = wot.fd_to_td(fd)
-        assert calculated.shape==(1+2*nfreq, 2) and np.allclose(calculated, td)
+        assert calculated.shape==(2*nfreq, 2) and np.allclose(calculated, td)
 
     def test_fd_to_td_1dof(self, fd_1dof, td_1dof, f1, nfreq):
         """Test the :python:`fd_to_td` function outputs for the 1 DOF
         case.
         """
         calculated = wot.fd_to_td(fd_1dof, f1, nfreq)
-        shape = (1+2*nfreq, 1)
+        shape = (2*nfreq, 1)
         calc_flat = calculated.squeeze()
         assert calculated.shape==shape and np.allclose(calc_flat, td_1dof)
 
@@ -748,7 +748,7 @@ class TestFDToTDToFD:
         for the 1 DOF.
         """
         calculated = wot.fd_to_td(fd_1dof)
-        shape = (1+2*nfreq, 1)
+        shape = (2*nfreq, 1)
         calc_flat = calculated.squeeze()
         assert calculated.shape==shape and np.allclose(calc_flat, td_1dof)
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -226,32 +226,32 @@ def mimo(nfreq_imp):
     ncomponents = wot.ncomponents(nfreq_imp)
     mimo = np.zeros([ncomponents*2, ncomponents*2])
     mimo[:ncomponents, :ncomponents] = np.array([
-        [0, 0,  0, 0,  0],
-        [0, 0, -1, 0,  0],
-        [0, 1,  0, 0,  0],
-        [0, 0,  0, 0, -2],
-        [0, 0,  0, 2,  0],
+        [0, 0,  0, 0], #  0
+        [0, 0, -1, 0], #  0
+        [0, 1,  0, 0], #  0
+        [0, 0,  0, 0], # -2
+    #   [0, 0,  0, 2], #  0
     ])
     mimo[ncomponents:, :ncomponents] = np.array([
-        [0, 0,  0,  0,  0],
-        [0, 1, -1,  0,  0],
-        [0, 1,  1,  0,  0],
-        [0, 0,  0, 11, -2],
-        [0, 0,  0,  2, 11],
+        [0, 0,  0,  0], #  0
+        [0, 1, -1,  0], #  0
+        [0, 1,  1,  0], #  0
+        [0, 0,  0, 11], # -2
+    #   [0, 0,  0,  2], # 11
     ])
     mimo[:ncomponents, ncomponents:] = np.array([
-        [0, 0,  0,  0,  0],
-        [0, 2, -1,  0,  0],
-        [0, 1,  2,  0,  0],
-        [0, 0,  0, 22, -2],
-        [0, 0,  0,  2, 22],
-        ])
+        [0, 0,  0,  0], #  0
+        [0, 2, -1,  0], #  0
+        [0, 1,  2,  0], #  0
+        [0, 0,  0, 22], # -2
+    #   [0, 0,  0,  2], # 22
+    ])
     mimo[ncomponents:, ncomponents:] = np.array([
-        [0, 0,  0,  0,  0],
-        [0, 3, -1,  0,  0],
-        [0, 1,  3,  0,  0],
-        [0, 0,  0, 33, -2],
-        [0, 0,  0,  2, 33],
+        [0, 0,  0,  0], #  0
+        [0, 3, -1,  0], #  0
+        [0, 1,  3,  0], #  0
+        [0, 0,  0, 33], # -2
+    #   [0, 0,  0,  2], # 33
     ])
     return mimo
 
@@ -262,11 +262,11 @@ class TestNComponents:
     def test_default(self, ncomponents, nfreq):
         """Test default, which will include a zero-frequency component.
         """
-        assert ncomponents == 2*nfreq + 1
+        assert ncomponents == 2*nfreq
 
     def test_nozero(self, nfreq):
         """Test without a zero-frequency component."""
-        assert wot.ncomponents(nfreq, False) == 2*nfreq
+        assert wot.ncomponents(nfreq, False) == 2*nfreq - 1
 
 
 class TestFrequency:
@@ -384,14 +384,13 @@ class TestTimeMat:
         """Correct/expected time matrix."""
         f = np.array([0, 1, 2])*f1_tm
         w = 2*np.pi * f
-        t = 1/(2*nfreq_tm+1) * 1/f1_tm * np.arange(0, 2*nfreq_tm+1)
+        t = 1/(2*nfreq_tm) * 1/f1_tm * np.arange(0, 2*nfreq_tm)
         c, s = np.cos, np.sin
         mat = np.array([
-            [1,            1,             0,            1,             0],
-            [1, c(w[1]*t[1]), -s(w[1]*t[1]), c(w[2]*t[1]), -s(w[2]*t[1])],
-            [1, c(w[1]*t[2]), -s(w[1]*t[2]), c(w[2]*t[2]), -s(w[2]*t[2])],
-            [1, c(w[1]*t[3]), -s(w[1]*t[3]), c(w[2]*t[3]), -s(w[2]*t[3])],
-            [1, c(w[1]*t[4]), -s(w[1]*t[4]), c(w[2]*t[4]), -s(w[2]*t[4])],
+            [1,            1,             0,            1],
+            [1, c(w[1]*t[1]), -s(w[1]*t[1]), c(w[2]*t[1])],
+            [1, c(w[1]*t[2]), -s(w[1]*t[2]), c(w[2]*t[2])],
+            [1, c(w[1]*t[3]), -s(w[1]*t[3]), c(w[2]*t[3])],
         ])
         return mat
 
@@ -419,7 +418,7 @@ class TestTimeMat:
         """Test the components at time zero of the time matrix with
         sub-steps.
         """
-        assert all(time_mat_sub[0, 1:]==np.array([1, 0]*nfreq))
+        assert all(time_mat_sub[0, 1:]==np.array([1, 0]*nfreq)[:-1])
 
     def test_behavior(self,):
         """Test that when the time matrix multiplies a state-vector it
@@ -429,7 +428,7 @@ class TestTimeMat:
         w = 2*np.pi*f
         time_mat = wot.time_mat(f, 1)
         x = 1.2 + 3.4j
-        X = np.reshape([0, np.real(x), np.imag(x)], [-1,1])
+        X = np.reshape([0, np.real(x), np.imag(x)], [-1,1])[:-1]
         x_t = time_mat @ X
         t = wot.time(f, 1)
         assert np.allclose(x_t.squeeze(), np.real(x*np.exp(1j*w*t)))
@@ -457,11 +456,10 @@ class TestDerivativeMat:
         """Correct/expected derivative matrix."""
         w0 = 2*np.pi*f1_dm
         mat = np.array([
-            [0,  0,   0,    0,     0],
-            [0,  0, -w0,    0,     0],
-            [0, w0,   0,    0,     0],
-            [0,  0,   0,    0, -2*w0],
-            [0,  0,   0, 2*w0,     0],
+            [0,  0,   0,    0],
+            [0,  0, -w0,    0],
+            [0, w0,   0,    0],
+            [0,  0,   0,    0],
         ])
         return mat
 
@@ -482,12 +480,19 @@ class TestDerivativeMat:
         """
         f = 0.1
         w = 2*np.pi*f
-        derivative_mat = wot.derivative_mat(f, 1)
-        x = 1.2 + 3.4j
-        X = np.reshape([0, np.real(x), np.imag(x)], [-1,1])
+        x = np.array([1 + 2j,
+                      3 + 4j,
+                      5 + 6j])
+        derivative_mat = wot.derivative_mat(f, np.size(x))
+        X = np.concatenate([
+            [0.],
+            np.reshape([[np.real(i), np.imag(i)] for i in x[:-1]], -1),
+            [np.real(x[-1])]
+        ])
         V = derivative_mat @ X
-        v = V[1] + 1j*V[2]
-        assert np.allclose(v, 1j*w*x)
+        v = np.sum(V[1::2]) + 1j*np.sum(V[2::2])
+        expected = np.sum([[(i+1) * 1j * w * x[i]] for i in range(np.size(x)-1)])
+        assert np.allclose(v, expected)
 
 
 class TestMIMOTransferMat:
@@ -505,11 +510,20 @@ class TestMIMOTransferMat:
         synthetic impedance.
         """
         # test use/behavior
-        x = 1.2+3.4j
-        X = np.reshape([0, np.real(x), np.imag(x)], [-1,1])
-        z = 2.1+4.3j
-        f = z*x
-        F = np.reshape([0, np.real(f), np.imag(f)], [-1,1])
+        x = np.array([1 + 2j,
+                      3 + 4j])
+        X = np.concatenate([
+            [0.],
+            np.reshape([[np.real(i), np.imag(i)] for i in x[:-1]], -1),
+            [np.real(x[-1])]
+        ])
+        z = np.array([1.5+2.5j,
+                      3.5+4.5j])
+        F = np.concatenate([
+            [0.],
+            np.reshape([[np.real(z[i]*x[i]), np.imag(z[i]*x[i])] for i in range(np.size(x)-1)], -1),
+            [np.real(z[-1]) * np.real(x[-1])],
+        ])
         Z_mimo = wot.mimo_transfer_mat(np.reshape([z], [1,1,-1]), False)
         assert np.allclose(Z_mimo @ X, F)
 
@@ -590,7 +604,7 @@ class TestRealToComplexToReal:
             # DOF 1,  DOF 2
             [  1+0j, 11+ 0j],  # f0
             [  2+3j, 12+13j],  # f1
-            [  4+5j, 14+15j],  # f2
+            [  4   , 14    ],  # f2 (real component only)
         ])
         return response
 
@@ -605,7 +619,6 @@ class TestRealToComplexToReal:
             [  2, 12],  # f1 real
             [  3, 13],  # f1 imag
             [  4, 14],  # f2 real
-            [  5, 15],  # f2 imag
         ])
         return response
 
@@ -645,7 +658,7 @@ class TestRealToComplexToReal:
         """
         complex_1d = np.array([1+0j, 2+3j])
         real_1d_calculated = wot.complex_to_real(complex_1d)
-        real_1d = np.array([[1], [2], [3]])
+        real_1d = np.array([[1], [2]])
         assert np.allclose(real_1d_calculated, real_1d)
 
 
@@ -712,7 +725,7 @@ class TestFDToTDToFD:
     def test_fd_to_td(self, fd, td, f1, nfreq):
         """Test the :python:`fd_to_td` function outputs."""
         calculated = wot.fd_to_td(fd, f1, nfreq)
-        assert calculated.shape==(2*nfreq+1, 2) and np.allclose(calculated, td)
+        assert calculated.shape==(2*nfreq, 2) and np.allclose(calculated, td)
 
     def test_td_to_fd(self, fd, td, f1, nfreq):
         """Test the :python:`td_to_fd` function outputs."""
@@ -885,7 +898,7 @@ class TestForceFromImpedanceOrTransferFunction:
     @pytest.fixture(scope="class")
     def x_wec(self,):
         """WEC position state vector for a simple synthetic case."""
-        return [0, 1, 1, 1, 1, 0, 2, 2, 2, 2]
+        return [0, 1, 1, 1, 1, 0, 2, 2, 2]
 
     @pytest.fixture(scope="class")
     def force(self, f1, nfreq_imp, ndof_imp):
@@ -902,12 +915,12 @@ class TestForceFromImpedanceOrTransferFunction:
         force[:, 0] = (
             A[0, 0] +
             A[0, 1]*np.cos(w[1]*t) - A[0, 2]*np.sin(w[1]*t) +
-            A[0, 3]*np.cos(w[2]*t) - A[0,4]*np.sin(w[2]*t)
+            A[0, 3]*np.cos(w[2]*t)
         )
         force[:, 1] = (
             A[1, 0] +
             A[1, 1]*np.cos(w[1]*t) - A[1, 2]*np.sin(w[1]*t) +
-            A[1, 3]*np.cos(w[2]*t) - A[1, 4]*np.sin(w[2]*t)
+            A[1, 3]*np.cos(w[2]*t)
         )
         return force
 
@@ -1032,7 +1045,7 @@ class TestInertiaStandardForces:
             f1, nfreq, {}, inertia_matrix=data['inertia_matrix'].values)
         waves = wot.waves.regular_wave(
             f1, nfreq, wave_freq, wave_amp, wave_phase_deg)
-        x_wec = np.zeros((nfreq*2+1)*ndof)
+        x_wec = np.zeros((nfreq*2)*ndof)
         x_wec[(index_freq*2-1)*1] = amplitude
         inertia_func = wot.inertia(
             f1, nfreq, inertia_matrix=data['inertia_matrix'].values)
@@ -1327,10 +1340,10 @@ class TestDecomposeState:
 
     def test_function(self,):
         """Test that the function returns expected results."""
-        ndof, nfreq = 1, 2  # ncomponents = ndof*(2*nfreq+1) = 5
-        state = [1, 1, 1, 1, 1, 3.4, 3.5]
-        x_wec = [1, 1, 1, 1, 1]
-        x_opt = [3.4, 3.5]
+        ndof, nfreq = 1, 2  # ncomponents = ndof*(2*nfreq-1)+1 = 4
+        state = [1, 1, 1, 1, 1, 3.4]
+        x_wec = [1, 1, 1, 1]
+        x_opt = [3.4]
         x_w_calc, x_o_calc = wot.decompose_state(state, ndof, nfreq)
         assert np.allclose(x_w_calc, x_wec) and np.allclose(x_o_calc, x_opt)
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -712,25 +712,25 @@ class TestFDToTDToFD:
     def test_fd_to_td(self, fd, td, f1, nfreq):
         """Test the :python:`fd_to_td` function outputs."""
         calculated = wot.fd_to_td(fd, f1, nfreq, full_2pt_wave=True)
-        assert calculated.shape==(2*nfreq, 2) and np.allclose(calculated, td)
+        assert calculated.shape==(2*nfreq+1, 2) and np.allclose(calculated, td)
 
     def test_td_to_fd(self, fd, td, f1, nfreq):
         """Test the :python:`td_to_fd` function outputs."""
         calculated = wot.td_to_fd(td, f1, nfreq)
-        assert calculated.shape==(1+nfreq, 2) and np.allclose(calculated, fd)
+        assert calculated.shape==(nfreq+1, 2) and np.allclose(calculated, fd)
 
     def test_fft(self, fd, td, nfreq):
         """Test the :python:`fd_to_td` function outputs when using FFT.
         """
         calculated = wot.fd_to_td(fd, full_2pt_wave=True)
-        assert calculated.shape==(2*nfreq, 2) and np.allclose(calculated, td)
+        assert calculated.shape==(2*nfreq+1, 2) and np.allclose(calculated, td)
 
     def test_fd_to_td_1dof(self, fd_1dof, td_1dof, f1, nfreq):
         """Test the :python:`fd_to_td` function outputs for the 1 DOF
         case.
         """
         calculated = wot.fd_to_td(fd_1dof, f1, nfreq, full_2pt_wave=True)
-        shape = (2*nfreq, 1)
+        shape = (2*nfreq+1, 1)
         calc_flat = calculated.squeeze()
         assert calculated.shape==shape and np.allclose(calc_flat, td_1dof)
 
@@ -739,7 +739,7 @@ class TestFDToTDToFD:
         case.
         """
         calculated = wot.td_to_fd(td_1dof.squeeze(), f1, nfreq)
-        shape = (1+nfreq, 1)
+        shape = (nfreq+1, 1)
         calc_flat = calculated.squeeze()
         assert calculated.shape==shape and np.allclose(calc_flat, fd_1dof)
 
@@ -748,7 +748,7 @@ class TestFDToTDToFD:
         for the 1 DOF.
         """
         calculated = wot.fd_to_td(fd_1dof, full_2pt_wave=True)
-        shape = (2*nfreq, 1)
+        shape = (2*nfreq+1, 1)
         calc_flat = calculated.squeeze()
         assert calculated.shape==shape and np.allclose(calc_flat, td_1dof)
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -38,7 +38,7 @@ def nsubsteps():
 @pytest.fixture(scope="module")
 def ncomponents(nfreq):
     """Number of components in the WEC state."""
-    return wot.ncomponents(nfreq)
+    return wot.ncomponents(nfreq, full_2pt_wave=True)
 
 
 @pytest.fixture(scope='module')
@@ -223,7 +223,7 @@ def mimo(nfreq_imp):
     """Correct MIMO matrix corresponding to the synthetic impedance
     matrix.
     """
-    ncomponents = wot.ncomponents(nfreq_imp)
+    ncomponents = wot.ncomponents(nfreq_imp, full_2pt_wave=True)
     mimo = np.zeros([ncomponents*2, ncomponents*2])
     mimo[:ncomponents, :ncomponents] = np.array([
         [0, 0,  0, 0,  0],
@@ -262,11 +262,11 @@ class TestNComponents:
     def test_default(self, ncomponents, nfreq):
         """Test default, which will include a zero-frequency component.
         """
-        assert ncomponents == 2*nfreq
+        assert ncomponents == 2*nfreq + 1
 
     def test_nozero(self, nfreq):
         """Test without a zero-frequency component."""
-        assert wot.ncomponents(nfreq, False) == 2*nfreq - 1
+        assert wot.ncomponents(nfreq, False, full_2pt_wave=True) == 2*nfreq
 
 
 class TestFrequency:
@@ -398,11 +398,11 @@ class TestTimeMat:
     @pytest.fixture(scope="class")
     def time_mat_sub(self, f1, nfreq, nsubsteps):
         """Time matrix with sub-steps."""
-        return wot.time_mat(f1, nfreq, nsubsteps)
+        return wot.time_mat(f1, nfreq, nsubsteps, full_2pt_wave=True)
 
     def test_time_mat(self, time_mat, f1_tm, nfreq_tm):
         """Test the default created time matrix."""
-        calculated = wot.time_mat(f1_tm, nfreq_tm)
+        calculated = wot.time_mat(f1_tm, nfreq_tm, full_2pt_wave=True)
         assert calculated==approx(time_mat)
 
     def test_shape(self, time_mat_sub, ncomponents, nsubsteps):
@@ -427,7 +427,7 @@ class TestTimeMat:
         """
         f = 0.1
         w = 2*np.pi*f
-        time_mat = wot.time_mat(f, 1)
+        time_mat = wot.time_mat(f, 1, full_2pt_wave=True)
         x = 1.2 + 3.4j
         X = np.reshape([0, np.real(x), np.imag(x)], [-1,1])
         x_t = time_mat @ X
@@ -467,12 +467,12 @@ class TestDerivativeMat:
 
     def test_derivative_mat(self, derivative_mat, f1_dm, nfreq_dm):
         """Test the default created derivative matrix."""
-        calculated = wot.derivative_mat(f1_dm, nfreq_dm)
+        calculated = wot.derivative_mat(f1_dm, nfreq_dm, full_2pt_wave=True)
         assert calculated==approx(derivative_mat)
 
     def test_no_mean(self, derivative_mat, f1_dm, nfreq_dm):
         """Test the derivative matrix without the mean component."""
-        calculated = wot.derivative_mat(f1_dm, nfreq_dm, False)
+        calculated = wot.derivative_mat(f1_dm, nfreq_dm, False, full_2pt_wave=True)
         assert calculated==approx(derivative_mat[1:, 1:])
 
     def test_behavior(self,):
@@ -482,7 +482,7 @@ class TestDerivativeMat:
         """
         f = 0.1
         w = 2*np.pi*f
-        derivative_mat = wot.derivative_mat(f, 1)
+        derivative_mat = wot.derivative_mat(f, 1, full_2pt_wave=True)
         x = 1.2 + 3.4j
         X = np.reshape([0, np.real(x), np.imag(x)], [-1,1])
         V = derivative_mat @ X
@@ -496,7 +496,7 @@ class TestMIMOTransferMat:
     def test_mimo_transfer_mat(self, impedance, mimo):
         """Test the function produces the correct MIMO transfer matrix.
         """
-        calculated = wot.mimo_transfer_mat(impedance, False)
+        calculated = wot.mimo_transfer_mat(impedance, False, full_2pt_wave=True)
         assert np.all(calculated == mimo)
 
     def test_behavior(self,):
@@ -510,7 +510,7 @@ class TestMIMOTransferMat:
         z = 2.1+4.3j
         f = z*x
         F = np.reshape([0, np.real(f), np.imag(f)], [-1,1])
-        Z_mimo = wot.mimo_transfer_mat(np.reshape([z], [1,1,-1]), False)
+        Z_mimo = wot.mimo_transfer_mat(np.reshape([z], [1,1,-1]), False, full_2pt_wave=True)
         assert np.allclose(Z_mimo @ X, F)
 
 
@@ -611,30 +611,30 @@ class TestRealToComplexToReal:
 
     def test_complex_to_real(self, complex_response, real_response):
         """Test converting from complex to real."""
-        calculated = wot.complex_to_real(complex_response)
+        calculated = wot.complex_to_real(complex_response, full_2pt_wave=True)
         assert np.allclose(calculated, real_response)
 
     def test_real_to_complex(self, complex_response, real_response):
         """Test converting from real to complex."""
-        calculated = wot.real_to_complex(real_response)
+        calculated = wot.real_to_complex(real_response, full_2pt_wave=True)
         assert np.allclose(calculated, complex_response)
 
     def test_cycle_real(self, real_response):
         """Test converting from real to complex and back to real."""
-        calculated = wot.real_to_complex(real_response)
-        calculated = wot.complex_to_real(calculated)
+        calculated = wot.real_to_complex(real_response, full_2pt_wave=True)
+        calculated = wot.complex_to_real(calculated, full_2pt_wave=True)
         assert np.allclose(calculated, real_response)
 
     def test_cycle_complex(self, complex_response):
         """Test converting from complex to real and back to complex."""
-        calculated = wot.complex_to_real(complex_response)
-        calculated = wot.real_to_complex(calculated)
+        calculated = wot.complex_to_real(complex_response, full_2pt_wave=True)
+        calculated = wot.real_to_complex(calculated, full_2pt_wave=True)
         assert np.allclose(calculated, complex_response)
 
     def test_shapes(self, complex_response, real_response):
         """Test output shapes."""
-        c_calc = wot.real_to_complex(real_response)
-        r_calc = wot.complex_to_real(c_calc)
+        c_calc = wot.real_to_complex(real_response, full_2pt_wave=True)
+        r_calc = wot.complex_to_real(c_calc, full_2pt_wave=True)
         c_shape = complex_response.shape
         r_shape = real_response.shape
         assert (c_calc.shape==c_shape) and (r_calc.shape==r_shape)
@@ -644,7 +644,7 @@ class TestRealToComplexToReal:
         input.
         """
         complex_1d = np.array([1+0j, 2+3j])
-        real_1d_calculated = wot.complex_to_real(complex_1d)
+        real_1d_calculated = wot.complex_to_real(complex_1d, full_2pt_wave=True)
         real_1d = np.array([[1], [2], [3]])
         assert np.allclose(real_1d_calculated, real_1d)
 
@@ -711,7 +711,7 @@ class TestFDToTDToFD:
 
     def test_fd_to_td(self, fd, td, f1, nfreq):
         """Test the :python:`fd_to_td` function outputs."""
-        calculated = wot.fd_to_td(fd, f1, nfreq)
+        calculated = wot.fd_to_td(fd, f1, nfreq, full_2pt_wave=True)
         assert calculated.shape==(2*nfreq, 2) and np.allclose(calculated, td)
 
     def test_td_to_fd(self, fd, td, f1, nfreq):
@@ -722,14 +722,14 @@ class TestFDToTDToFD:
     def test_fft(self, fd, td, nfreq):
         """Test the :python:`fd_to_td` function outputs when using FFT.
         """
-        calculated = wot.fd_to_td(fd)
+        calculated = wot.fd_to_td(fd, full_2pt_wave=True)
         assert calculated.shape==(2*nfreq, 2) and np.allclose(calculated, td)
 
     def test_fd_to_td_1dof(self, fd_1dof, td_1dof, f1, nfreq):
         """Test the :python:`fd_to_td` function outputs for the 1 DOF
         case.
         """
-        calculated = wot.fd_to_td(fd_1dof, f1, nfreq)
+        calculated = wot.fd_to_td(fd_1dof, f1, nfreq, full_2pt_wave=True)
         shape = (2*nfreq, 1)
         calc_flat = calculated.squeeze()
         assert calculated.shape==shape and np.allclose(calc_flat, td_1dof)
@@ -747,7 +747,7 @@ class TestFDToTDToFD:
         """Test the :python:`fd_to_td` function outputs when using FFT
         for the 1 DOF.
         """
-        calculated = wot.fd_to_td(fd_1dof)
+        calculated = wot.fd_to_td(fd_1dof, full_2pt_wave=True)
         shape = (2*nfreq, 1)
         calc_flat = calculated.squeeze()
         assert calculated.shape==shape and np.allclose(calc_flat, td_1dof)
@@ -896,7 +896,7 @@ class TestForceFromImpedanceOrTransferFunction:
             [0, 1,  7, 38, 50],
             [0, 4, 10, 71, 83],
         ])
-        force = np.zeros((wot.ncomponents(nfreq_imp), ndof_imp))
+        force = np.zeros((wot.ncomponents(nfreq_imp, full_2pt_wave=True), ndof_imp))
         w = wot.frequency(f1, nfreq_imp) * 2*np.pi
         t = wot.time(f1, nfreq_imp)
         force[:, 0] = (
@@ -943,7 +943,7 @@ class TestForceFromWaves:
         """Test regular wave forces."""
         # correct
         A = fexc_regular
-        force = np.zeros((wot.ncomponents(nfreq), ndof_waves))
+        force = np.zeros((wot.ncomponents(nfreq, full_2pt_wave=True), ndof_waves))
         w = wot.frequency(f1, nfreq) * 2*np.pi
         w = w[1:]
         t = wot.time(f1, nfreq)
@@ -965,7 +965,7 @@ class TestForceFromWaves:
         """Test iregular wave forces."""
         # correct
         A = fexc_multi
-        force = np.zeros((wot.ncomponents(nfreq), ndof_waves))
+        force = np.zeros((wot.ncomponents(nfreq, full_2pt_wave=True), ndof_waves))
         w = wot.frequency(f1, nfreq) * 2*np.pi
         w = w[1:]
         t = wot.time(f1, nfreq)
@@ -1029,7 +1029,7 @@ class TestInertiaStandardForces:
         forces = wot.standard_forces(data)
         # calculated inertia and forces
         wec = wot.WEC(
-            f1, nfreq, {}, inertia_matrix=data['inertia_matrix'].values)
+            f1, nfreq, {}, inertia_matrix=data['inertia_matrix'].values, full_2pt_wave=True)
         waves = wot.waves.regular_wave(
             f1, nfreq, wave_freq, wave_amp, wave_phase_deg)
         x_wec = np.zeros((nfreq*2+1)*ndof)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -418,7 +418,7 @@ class TestTimeMat:
         """Test the components at time zero of the time matrix with
         sub-steps.
         """
-        assert all(time_mat_sub[0, 1:]==np.array([1, 0]*(nfreq-1)))
+        assert all(time_mat_sub[0, 1:]==np.array([1, 0]*nfreq)[:-1])
 
     def test_behavior(self,):
         """Test that when the time matrix multiplies a state-vector it
@@ -428,7 +428,7 @@ class TestTimeMat:
         w = 2*np.pi*f
         time_mat = wot.time_mat(f, 1)
         x = 1.2 + 3.4j
-        X = np.concatenate([0, np.real(x), np.imag(x[:-1])])
+        X = np.reshape([0, np.real(x), np.imag(x)], [-1,1])[:-1]
         x_t = time_mat @ X
         t = wot.time(f, 1)
         assert np.allclose(x_t.squeeze(), np.real(x*np.exp(1j*w*t)))

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -158,7 +158,7 @@ def test_solve_callback(wec_from_bem, regular_wave, pto, nfreq, capfd):
 
     _ = wec_from_bem.solve(regular_wave,
                            obj_fun=pto.average_power,
-                           nstate_opt=2*nfreq+1,
+                           nstate_opt=2*nfreq,
                            scale_x_wec=1.0,
                            scale_x_opt=0.01,
                            scale_obj=1e-1,
@@ -321,7 +321,7 @@ class TestTheoreticalPowerLimits:
 
         res = wec.solve(waves=regular_wave,
                         obj_fun=pto.average_power,
-                        nstate_opt=2*nfreq+1,
+                        nstate_opt=2*nfreq,
                         x_wec_0=1e-1*np.ones(wec.nstate_wec),
                         scale_x_wec=1e2,
                         scale_x_opt=1e-2,

--- a/tests/test_pto.py
+++ b/tests/test_pto.py
@@ -123,20 +123,18 @@ class TestSupportFunctions:
     def test_make_mimo_transfer_mat(self, abcd, ndof, nfreq):
         """Test the function :python:`pto._mimo_transfer_mat`"""
         mimo = wot.pto._make_mimo_transfer_mat(abcd, ndof)
-        n = 2*nfreq+1
+        n = 2*nfreq
         expected = np.zeros([2*ndof*n, 2*ndof*n])
         # 0,0
         imp = abcd[0, 0, :]
         r0 = np.real(imp[0])
         i0 = np.imag(imp[0])
         r1 = np.real(imp[1])
-        i1 = np.imag(imp[1])
         expected[:n, :n] = np.array([
-            [0, 0,    0, 0,    0],
-            [0, r0, -i0, 0,    0],
-            [0, i0,  r0, 0,    0],
-            [0, 0,    0, r1, -i1],
-            [0, 0,    0, i1,  r1]
+            [0, 0,    0, 0],
+            [0, r0, -i0, 0],
+            [0, i0,  r0, 0],
+            [0, 0,    0, r1],
         ])
         # 0,1
         imp = abcd[0, 1, :]
@@ -145,37 +143,32 @@ class TestSupportFunctions:
         r1 = np.real(imp[1])
         i1 = np.imag(imp[1])
         expected[:n, n:] = np.array([
-            [0, 0,    0, 0,    0],
-            [0, r0, -i0, 0,    0],
-            [0, i0,  r0, 0,    0],
-            [0, 0,    0, r1, -i1],
-            [0, 0,    0, i1,  r1]
+            [0, 0,    0, 0],
+            [0, r0, -i0, 0],
+            [0, i0,  r0, 0],
+            [0, 0,    0, r1],
         ])
         # 1,0
         imp = abcd[1, 0, :]
         r0 = np.real(imp[0])
         i0 = np.imag(imp[0])
         r1 = np.real(imp[1])
-        i1 = np.imag(imp[1])
         expected[n:, :n] = np.array([
-            [0, 0,    0, 0,    0],
-            [0, r0, -i0, 0,    0],
-            [0, i0,  r0, 0,    0],
-            [0, 0,    0, r1, -i1],
-            [0, 0,    0, i1,  r1]
+            [0, 0,    0, 0],
+            [0, r0, -i0, 0],
+            [0, i0,  r0, 0],
+            [0, 0,    0, r1],
         ])
         # 1,1
         imp = abcd[1, 1, :]
         r0 = np.real(imp[0])
         i0 = np.imag(imp[0])
         r1 = np.real(imp[1])
-        i1 = np.imag(imp[1])
         expected[n:, n:] = np.array([
-            [0, 0,    0, 0,    0],
-            [0, r0, -i0, 0,    0],
-            [0, i0,  r0, 0,    0],
-            [0, 0,    0, r1, -i1],
-            [0, 0,    0, i1,  r1]
+            [0, 0,    0, 0],
+            [0, r0, -i0, 0],
+            [0, i0,  r0, 0],
+            [0, 0,    0, r1],
         ])
         # test
         assert np.allclose(mimo, expected)
@@ -215,10 +208,10 @@ class TestControllers:
         controller = wot.pto.controller_unstructured
         pto = wot.pto.PTO(ndof, kinematics, controller)
         amp = 1.2
-        w = omega[-1]
+        w = omega[-2]
         force = amp * np.cos(w * wec.time)
         force = force.reshape(-1, 1)
-        x_opt = [0, 0, 0, amp, 0]
+        x_opt = [0, amp, 0, 0]
         calculated = pto.force(wec, None, x_opt, None)
         assert np.allclose(force, calculated)
 
@@ -227,12 +220,12 @@ class TestControllers:
         controller = wot.pto.controller_p
         pto = wot.pto.PTO(ndof, kinematics, controller)
         amp = 2.3
-        w = omega[-1]
+        w = omega[-2]
         # pos = amp * np.cos(w * wec.time)
         vel = -1 * amp * w * np.sin(w * wec.time)
         force = vel*pid_p
         force = force.reshape(-1, 1)
-        x_wec = [0, 0, 0, amp, 0]
+        x_wec = [0, amp, 0, 0]
         x_opt = [pid_p,]
         calculated = pto.force(wec, x_wec, x_opt, None)
         assert np.allclose(force, calculated)
@@ -242,12 +235,12 @@ class TestControllers:
         controller = wot.pto.controller_pi
         pto = wot.pto.PTO(ndof, kinematics, controller)
         amp = 2.3
-        w = omega[-1]
+        w = omega[-2]
         pos = amp * np.cos(w * wec.time)
         vel = -1 * amp * w * np.sin(w * wec.time)
         force = vel*pid_p + pos*pid_i
         force = force.reshape(-1, 1)
-        x_wec = [0, 0, 0, amp, 0]
+        x_wec = [0, amp, 0, 0]
         x_opt = [pid_p, pid_i]
         calculated = pto.force(wec, x_wec, x_opt, None)
         assert np.allclose(force, calculated)
@@ -259,13 +252,13 @@ class TestControllers:
         controller = wot.pto.controller_pid
         pto = wot.pto.PTO(ndof, kinematics, controller)
         amp = 2.3
-        w = omega[-1]
+        w = omega[-2]
         pos = amp * np.cos(w * wec.time)
         vel = -1 * amp * w * np.sin(w * wec.time)
         acc = -1 * amp * w**2 * np.cos(w * wec.time)
         force = vel*pid_p + pos*pid_i + acc*pid_d
         force = force.reshape(-1, 1)
-        x_wec = [0, 0, 0, amp, 0]
+        x_wec = [0, amp, 0, 0]
         x_opt = [pid_p, pid_i, pid_d]
         calculated = pto.force(wec, x_wec, x_opt, None)
         assert np.allclose(force, calculated)

--- a/tests/test_waves.py
+++ b/tests/test_waves.py
@@ -260,7 +260,7 @@ class TestLongCrestedWave:
             noverlap=0
         )
         # check it is equal to the original spectrum
-        assert np.allclose(S_data[1:], pm_spectrum.values.squeeze())
+        assert np.allclose(S_data[1:-1], pm_spectrum.values.squeeze()[:-1])
 
 
 class TestIrregularWave:

--- a/wecopttool/core.py
+++ b/wecopttool/core.py
@@ -1511,7 +1511,7 @@ def real_to_complex(
         mean = fd[0:1, :]
         fd = fd[1:, :]
     fdc = np.append(fd[0:-1:2, :] + 1j*fd[1::2, :],
-                    fd[-1, :].reshape(-1, 1), axis=0)
+                    [fd[-1, :]], axis=0)
     if zero_freq:
         fdc = np.concatenate((mean, fdc), axis=0)
     return fdc

--- a/wecopttool/core.py
+++ b/wecopttool/core.py
@@ -1308,7 +1308,7 @@ def time(
     """
     if nsubsteps < 1:
         raise ValueError("'nsubsteps' must be 1 or greater")
-    nsteps = nsubsteps * ncomponents(nfreq)
+    nsteps = nsubsteps * ncomponents(nfreq, full_2pt_wave=True)
     return np.linspace(0, 1/f1, nsteps, endpoint=False)
 
 

--- a/wecopttool/core.py
+++ b/wecopttool/core.py
@@ -1336,7 +1336,7 @@ def time_mat(
     t = time(f1, nfreq, nsubsteps)
     omega = frequency(f1, nfreq) * 2*np.pi
     wt = np.outer(t, omega[1:])
-    ncomp = ncomponents(nfreq, zero_freq=zero_freq)
+    ncomp = ncomponents(nfreq)
     time_mat = np.empty((nsubsteps*ncomp, ncomp))
     time_mat[:, 0] = 1.0
     time_mat[:, 1::2] = np.cos(wt)

--- a/wecopttool/core.py
+++ b/wecopttool/core.py
@@ -1245,7 +1245,7 @@ def ncomponents(
     ncomp = 2*nfreq
     if zero_freq:
         ncomp = ncomp + 1
-    if full_2pt_wave:
+    if not full_2pt_wave:
         ncomp = ncomp - 1
     return ncomp
 
@@ -1385,7 +1385,7 @@ def derivative_mat(
     if zero_freq:
         blocks = [0.0] + blocks
     deriv_mat = block_diag(*blocks)
-    if full_2pt_wave:
+    if not full_2pt_wave:
         deriv_mat = deriv_mat[:-1, :-1]
     return deriv_mat
 
@@ -1439,7 +1439,7 @@ def mimo_transfer_mat(
             blocks =[Zp0] + blocks
             elem[idof][jdof] = block_diag(*blocks)
     mimo_mat = np.block(elem)
-    if full_2pt_wave:
+    if not full_2pt_wave:
         mimo_mat = mimo_mat[:-1, :-1]
     return mimo_mat
 

--- a/wecopttool/core.py
+++ b/wecopttool/core.py
@@ -1425,7 +1425,7 @@ def mimo_transfer_mat(
             re = np.real(Zp)
             im = np.imag(Zp)
             blocks = [block(ire, iim) for (ire, iim) in zip(re[:-1], im[:-1])]
-            blocks =[Zp0] + blocks + [re[-1]]
+            blocks = [Zp0] + blocks + [re[-1]]
             elem[idof][jdof] = block_diag(*blocks)
     return np.block(elem)
 
@@ -1629,7 +1629,7 @@ def fd_to_td(
         tmat = time_mat(f1, nfreq, zero_freq=zero_freq)
         td = tmat @ complex_to_real(fd, zero_freq)
     elif (f1 is None) and (nfreq is None):
-        n = 1 + 2*(fd.shape[0]-1)
+        n = 2*(fd.shape[0]-1)
         td = np.fft.irfft(fd/2, n=n, axis=0, norm='forward')
     else:
         raise ValueError(

--- a/wecopttool/core.py
+++ b/wecopttool/core.py
@@ -1241,7 +1241,7 @@ def ncomponents(
     zero_freq
         Whether to include the zero-frequency.
     """
-    ncomp = 2*nfreq
+    ncomp = 2*nfreq -1 ###
     if zero_freq:
         ncomp = ncomp + 1
     return ncomp
@@ -1340,7 +1340,7 @@ def time_mat(
     time_mat = np.empty((nsubsteps*ncomp, ncomp))
     time_mat[:, 0] = 1.0
     time_mat[:, 1::2] = np.cos(wt)
-    time_mat[:, 2::2] = -np.sin(wt)
+    time_mat[:, 2::2] = -np.sin(wt[:, :-1]) ###
     if not zero_freq:
         time_mat = time_mat[:, 1:]
     return time_mat
@@ -1376,7 +1376,7 @@ def derivative_mat(
     blocks = [block(n+1) for n in range(nfreq)]
     if zero_freq:
         blocks = [0.0] + blocks
-    return block_diag(*blocks)
+    return block_diag(*blocks)[:-1, :-1] ###
 
 
 def mimo_transfer_mat(
@@ -1423,10 +1423,10 @@ def mimo_transfer_mat(
                 Zp = transfer_mat[idof, jdof, :]
             re = np.real(Zp)
             im = np.imag(Zp)
-            blocks = [block(ire, iim) for (ire, iim) in zip(re, im)]
+            blocks = [block(ire, iim) for (ire, iim) in zip(re, im)] ###
             blocks =[Zp0] + blocks
             elem[idof][jdof] = block_diag(*blocks)
-    return np.block(elem)
+    return np.block(elem)[:-1, :-1] ###
 
 
 def vec_to_dofmat(vec: ArrayLike, ndof: int) -> ndarray:
@@ -1558,12 +1558,12 @@ def complex_to_real(
         b = np.real(fd)
         c = np.imag(fd)
     out = np.concatenate([np.transpose(b), np.transpose(c)])
-    out = np.reshape(np.reshape(out, [-1], order='F'), [-1, ndof])
+    out = np.reshape(np.reshape(out, [-1], order='F'), [-1, ndof])[:-1] ###
     if zero_freq:
         out = np.concatenate([a, out])
-        assert out.shape == (2*nfreq+1, ndof)
-    else:
         assert out.shape == (2*nfreq, ndof)
+    else:
+        assert out.shape == (2*nfreq-1, ndof)
     return out
 
 

--- a/wecopttool/core.py
+++ b/wecopttool/core.py
@@ -453,7 +453,7 @@ class WEC:
             :python:`fun` has a  signature
             :python:`def fun(wec, x_wec, x_opt, waves):`, and returns
             forces in the time-domain of size
-            :python:`(2*nfreq+1, ndof)`.
+            :python:`(2*nfreq, ndof)`.
         constraints
             List of constraints, see documentation for
             :py:func:`scipy.optimize.minimize` for description and
@@ -534,7 +534,7 @@ class WEC:
             :python:`fun` has a  signature
             :python:`def fun(wec, x_wec, x_opt, waves):`, and returns
             forces in the time-domain of size
-            :python:`(2*nfreq+1, ndof)`.
+            :python:`(2*nfreq, ndof)`.
         constraints
             List of constraints, see documentation for
             :py:func:`scipy.optimize.minimize` for description and
@@ -1010,7 +1010,7 @@ class WEC:
 
     @property
     def time(self) -> ndarray:
-        """Time vector [s], size '(2*nfreq+1, ndof)', not containing the
+        """Time vector [s], size '(2*nfreq, ndof)', not containing the
         end time 'tf'."""
         return self._time
 
@@ -1018,10 +1018,11 @@ class WEC:
     def time_mat(self) -> ndarray:
         """Matrix to create time-series from Fourier coefficients.
 
-        For some array of Fourier coefficients :python:`x`, size
-        :python:`(2*nfreq+1, ndof)`, the time series, also size
-        :python:`(2*nfreq+1, ndof)`, is obtained as
-        :python:`time_mat @ x`.
+        For some array of Fourier coefficients :python:`x`
+        (excluding the sine component of the highest freequency), size
+        :python:`(2*nfreq, ndof)`, the time series is obtained via
+        :python:`time_mat @ x`, also size
+        :python:`(2*nfreq, ndof)`.
         """
         return self._time_mat
 
@@ -1030,9 +1031,10 @@ class WEC:
         """Matrix to create Fourier coefficients of the derivative of
         some quantity.
 
-        For some array of Fourier coefficients :python:`x`, size
-        :python:`(2*nfreq+1, ndof)`, the Fourier coefficients of the
-        derivative of :python:`x` are obtained as
+        For some array of Fourier coefficients :python:`x`
+        (excluding the sine component of the highest freequency), size
+        :python:`(2*nfreq, ndof)`, the Fourier coefficients of the
+        derivative of :python:`x` are obtained via
         :python:`derivative_mat @ x`.
         """
         return self._derivative_mat
@@ -1056,8 +1058,10 @@ class WEC:
 
     @property
     def ncomponents(self) -> int:
-        """Number of Fourier components (:python:`2*nfreq + 1`) for each
-        degree of freedom.
+        """Number of Fourier components (:python:`2*nfreq`) for each
+        degree of freedom. Note that the sine component of the highest
+        frequency (the 2-point wave) is excluded as this will always
+        evaluate to zero.
         """
         return ncomponents(self.nfreq)
 
@@ -1216,7 +1220,7 @@ class WEC:
         ----------
         td
             Time-domain real array with shape
-            :python:`(2*WEC.nfreq+1, N)` for any :python:`N`.
+            :python:`(2*WEC.nfreq, N)` for any :python:`N`.
         fft
             Whether to use the real FFT.
 
@@ -1231,8 +1235,12 @@ def ncomponents(
     nfreq : int,
     zero_freq: Optional[bool] = True,
 ) -> int:
-    """Number of Fourier components (:python:`2*nfreq + 1`) for each
-    DOF.
+    """Number of Fourier components (:python:`2*nfreq`) for each
+    DOF. The sine component of the highest frequency (the 2-point wave)
+    is excluded as it will always evaluate to zero.
+
+    If :python:`zero_freq = False` (not default), the mean (DC) component
+    :python:`X0` is excluded, and the number of components is reduced by 1.
 
     Parameters
     ----------
@@ -1260,6 +1268,9 @@ def frequency(
     Returns the frequency array, e.g.,
     :python:`freqs = [0, f1, 2*f1, ..., nfreq*f1]`.
 
+    If :python:`zero_freq = False` (not default), the mean (DC) component
+    :python:`0` is excluded, and the vector length is reduced by 1.
+
     Parameters
     ----------
     f1
@@ -1283,9 +1294,9 @@ def time(
 
     Returns the 1D time vector, in seconds, starting at time
     :python:`0`, and not containing the end time :python:`tf=1/f1`.
-    The time vector has length :python:`(2*nfreq+1)*nsubsteps`.
+    The time vector has length :python:`(2*nfreq)*nsubsteps`.
     The timestep length is :python:`dt = dt_default * 1/nsubsteps`,
-    where :python:`dt_default=tf/(2*nfreq+1)`.
+    where :python:`dt_default=tf/(2*nfreq)`.
 
     Parameters
     ----------
@@ -1314,12 +1325,15 @@ def time_mat(
 
     For a state :math:`x` consisting of the mean (DC) component
     followed by the real and imaginary components of the Fourier
-    coefficients as
-    :math:`x=[X0, Re(X1), Im(X1), ..., Re(Xn), Im(Xn)]`,
+    coefficients (excluding the imaginary component of the 2-point wave) as
+    :math:`x=[X0, Re(X1), Im(X1), ..., Re(Xn)]`,
     the response vector in the time-domain (:math:`x(t)`) is given as
     :math:`Mx`, where :math:`M` is the time matrix.
 
-    The time matrix has size :python:`(nfreq*2+1, nfreq*2+1)`.
+    The time matrix has size :python:`(nfreq*2, nfreq*2)`.
+
+    If :python:`zero_freq = False` (not default), the mean (DC) component
+    :python:`X0` is excluded, and the matrix/vector length is reduced by 1.
 
     Parameters
     ---------
@@ -1356,12 +1370,15 @@ def derivative_mat(
 
     For a state :math:`x` consisting of the mean (DC) component
     followed by the real and imaginary components of the Fourier
-    coefficients as
-    :math:`x=[X0, Re(X1), Im(X1), ..., Re(Xn), Im(Xn)]`,
+    coefficients (excluding the imaginary component of the 2-point wave) as
+    :math:`x=[X0, Re(X1), Im(X1), ..., Re(Xn)]`,
     the state of its derivative is given as :math:`Dx`, where
     :math:`D` is the derivative matrix.
 
-    The derivative matrix has size :python:`(nfreq*2+1, nfreq*2+1)`.
+    The time matrix has size :python:`(nfreq*2, nfreq*2)`.
+
+    If :python:`zero_freq = False` (not default), the mean (DC) component
+    :python:`X0` is excluded, and the matrix/vector length is reduced by 1.
 
     Parameters
     ---------
@@ -1398,8 +1415,12 @@ def mimo_transfer_mat(
     output variable.
     Here, a state representation :python:`x` consists of the mean (DC)
     component followed by the real and imaginary components of the
-    Fourier coefficients as
-    :python:`x=[X0, Re(X1), Im(X1), ..., Re(Xn), Im(Xn)]`.
+    Fourier coefficients (excluding the imaginary component of the
+    2-point wave) as
+    :python:`x=[X0, Re(X1), Im(X1), ..., Re(Xn)]`.
+    
+    If :python:`zero_freq = False` (not default), the mean (DC) component
+    :python:`X0` is excluded, and the matrix/vector length is reduced by 1.
 
     Parameters
     ----------
@@ -1481,10 +1502,11 @@ def real_to_complex(
 
     The input is a real 2D array with each column containing the real
     and imaginary components of the Fourier coefficients for some
-    response.
-    The column length is :python:`2*nfreq+1`.
+    response, excluding the imaginary component of the highest frequency
+    (2-point wave).
+    The column length is :python:`2*nfreq`.
     The entries of a column representing a response :python:`x` are
-    :python:`x=[X0, Re(X1), Im(X1), ..., Re(Xn), Im(Xn)]`.
+    :python:`x=[X0, Re(X1), Im(X1), ..., Re(Xn)]`.
 
     Returns a complex 2D array with each column containing the complex
     Fourier coefficients.
@@ -1492,6 +1514,9 @@ def real_to_complex(
     to the real-valued zero-frequency (mean, DC) components.
     The entries of a column representing a response :python:`x` are
     :python:`x=[X0, X1, ..., Xn]`.
+
+    If :python:`zero_freq = False`, the mean (DC) component :python:`X0`
+    is excluded, and the column length is reduced by 1.
 
     Parameters
     ----------
@@ -1532,10 +1557,15 @@ def complex_to_real(
     :python:`x=[X0, X1, ..., Xn]`.
 
     Returns a real 2D array with each column containing the real and
-    imaginary components of the Fourier coefficients.
-    The column length is :python:`2*nfreq+1`.
+    imaginary components of the Fourier coefficients. The imaginary component
+    of the highest frequency (the 2-point wave) is excluded, as it will
+    always evaluate to zero.
+    The column length is :python:`2*nfreq`.
     The entries of a column representing a response :python:`x` are
-    :python:`x=[X0, Re(X1), Im(X1), ..., Re(Xn), Im(Xn)]`.
+    :python:`x=[X0, Re(X1), Im(X1), ..., Re(Xn)]`.
+
+    If :python:`zero_freq = False` (not default), the mean (DC) component
+    :python:`X0` is excluded, and the vector length is reduced by 1.
 
     Parameters
     ----------
@@ -1589,12 +1619,17 @@ def fd_to_td(
     :python:`x=[X0, X1, ..., Xn]`.
 
     Returns a real array with same number of columns and
-    :python:`2*nfreq+1` rows, containing the time-domain response at
+    :python:`2*nfreq` rows, containing the time-domain response at
     times :python:`wecopttool.time(f1, nfreq, nsubsteps=1)`.
+    The imaginary component of the highest frequency (the 2-point wave) is
+    excluded, as it will always evaluate to zero.
 
     If both :python:`f1` and :python:`nfreq` are provided, it uses the
     time matrix :python:`wecopttool.time_mat(f1, nfreq, nsubsteps=1)`,
     else it uses the inverse real FFT (:py:func:`numpy.fft.irfft`).
+
+    If :python:`zero_freq = False` (not default), the mean (DC) component
+    :python:`X0` is excluded, and the matrix/vector length is reduced by 1.
 
     Opposite of :py:meth:`wecopttool.td_to_fd`.
 
@@ -1644,6 +1679,9 @@ def td_to_fd(
 ) -> ndarray:
     """Convert a real array of time-domain responses to a complex array
     of Fourier coefficients.
+
+    If :python:`zero_freq = False` (not default), the mean (DC) component
+    :python:`X0` is excluded, and the matrix/vector length is reduced by 1.
 
     Opposite of :py:func:`wecopttool.fd_to_td`
 
@@ -1790,6 +1828,9 @@ def force_from_rao_transfer_function(
 
     This is the position equivalent to the velocity-based
     :py:func:`wecopttool.force_from_impedance`.
+
+    If :python:`zero_freq = False` (not default), the mean (DC) component
+    of the transfer matrix (first row) is excluded.
 
     Parameters
     ----------
@@ -2337,7 +2378,9 @@ def frequency_parameters(
 
     This function can be used as a check for inputs to other functions
     since it raises an error if the frequency vector does not have
-    the correct format :python:`freqs = [0, f1, 2*f1, ..., nfreq*f1]`.
+    the correct format :python:`freqs = [0, f1, 2*f1, ..., nfreq*f1]`
+    (or :python:`freqs = [f1, 2*f1, ..., nfreq*f1] if
+    :python:`zero_freq = False`).
 
     Parameters
     ----------

--- a/wecopttool/pto.py
+++ b/wecopttool/pto.py
@@ -706,6 +706,7 @@ def _make_mimo_transfer_mat(
             Zp = impedance_abcd[idof, jdof, :]
             re = np.real(Zp)
             im = np.imag(Zp)
+            # Exclude the sine component of the 2-point wave
             blocks = [block(ire, iim) for (ire, iim) in zip(re[:-1], im[:-1])]
             blocks = [0.0] + blocks + [re[-1]]
             elem[idof][jdof] = block_diag(*blocks)

--- a/wecopttool/pto.py
+++ b/wecopttool/pto.py
@@ -450,14 +450,17 @@ class PTO:
         if self.impedance is not None:
             q1_td = self.velocity(wec, x_wec, x_opt, waves)
             e1_td = self.force(wec, x_wec, x_opt, waves)
-            q1 = complex_to_real(td_to_fd(q1_td, False))
-            e1 = complex_to_real(td_to_fd(e1_td, False))
+            q1 = complex_to_real(td_to_fd(q1_td, False), full_2pt_wave=True)
+            e1 = complex_to_real(td_to_fd(e1_td, False), full_2pt_wave=True)
             vars_1 = np.hstack([q1, e1])
             vars_1_flat = dofmat_to_vec(vars_1)
             vars_2_flat = np.dot(self.transfer_mat, vars_1_flat)
             vars_2 = vec_to_dofmat(vars_2_flat, 2*self.ndof)
             q2 = vars_2[:, :self.ndof]
             e2 = vars_2[:, self.ndof:]
+            if not wec._full_2pt_wave:
+                q2 = q2[:-1, :]
+                e2 = e2[:-1, :]
             time_mat = self._tmat(wec, nsubsteps)
             q2_td = np.dot(time_mat, q2)
             e2_td = np.dot(time_mat, e2)

--- a/wecopttool/pto.py
+++ b/wecopttool/pto.py
@@ -456,8 +456,8 @@ class PTO:
             vars_1_flat = dofmat_to_vec(vars_1)
             vars_2_flat = np.dot(self.transfer_mat, vars_1_flat)
             vars_2 = vec_to_dofmat(vars_2_flat, 2*self.ndof)
-            q2 = vars_2[:-1, :self.ndof]
-            e2 = vars_2[:-1, self.ndof:]
+            q2 = vars_2[:, :self.ndof]
+            e2 = vars_2[:, self.ndof:]
             time_mat = self._tmat(wec, nsubsteps)
             q2_td = np.dot(time_mat, q2)
             e2_td = np.dot(time_mat, e2)
@@ -706,8 +706,8 @@ def _make_mimo_transfer_mat(
             Zp = impedance_abcd[idof, jdof, :]
             re = np.real(Zp)
             im = np.imag(Zp)
-            blocks = [block(ire, iim) for (ire, iim) in zip(re, im)]
-            blocks = [0.0] + blocks
+            blocks = [block(ire, iim) for (ire, iim) in zip(re[:-1], im[:-1])]
+            blocks = [0.0] + blocks + [re[-1]]
             elem[idof][jdof] = block_diag(*blocks)
     return np.block(elem)
 

--- a/wecopttool/pto.py
+++ b/wecopttool/pto.py
@@ -450,17 +450,14 @@ class PTO:
         if self.impedance is not None:
             q1_td = self.velocity(wec, x_wec, x_opt, waves)
             e1_td = self.force(wec, x_wec, x_opt, waves)
-            q1 = complex_to_real(td_to_fd(q1_td, False), full_2pt_wave=True)
-            e1 = complex_to_real(td_to_fd(e1_td, False), full_2pt_wave=True)
+            q1 = complex_to_real(td_to_fd(q1_td, False))
+            e1 = complex_to_real(td_to_fd(e1_td, False))
             vars_1 = np.hstack([q1, e1])
             vars_1_flat = dofmat_to_vec(vars_1)
             vars_2_flat = np.dot(self.transfer_mat, vars_1_flat)
             vars_2 = vec_to_dofmat(vars_2_flat, 2*self.ndof)
-            q2 = vars_2[:, :self.ndof]
-            e2 = vars_2[:, self.ndof:]
-            if not wec._full_2pt_wave:
-                q2 = q2[:-1, :]
-                e2 = e2[:-1, :]
+            q2 = vars_2[:-1, :self.ndof]
+            e2 = vars_2[:-1, self.ndof:]
             time_mat = self._tmat(wec, nsubsteps)
             q2_td = np.dot(time_mat, q2)
             e2_td = np.dot(time_mat, e2)


### PR DESCRIPTION
## Description
As the imaginary component of the highest sampled frequency will always evaluate to zero, it does not provide any meaningful gradient information to the optimization algorithm, and thus slows down the solve step unnecessarily. This removes this component from WecOptTool entirely (reducing the number of states by 1) to improve performance, and updates the docstrings, tutorials, and unit testing suite to reflect this. Resolves #181.

## Type of PR
- [x] New feature

## Checklist for PR
- [x] Authors read the [contribution guidelines](https://github.com/SNL-WaterPower/WecOptTool/blob/main/.github/CONTRIBUTING.md)
- [x] The pull request is from an issue branch (not main) on *your* fork, to the [main branch in WecOptTool](https://github.com/SNL-WaterPower/WecOptTool).
- [x] The authors have given the admins edit access
- [x] All changes adhere to the style guide including PEP8, Docstrings, and Type Hints.
- [x] Modified the documentation if applicable
- [x] Modified or added a new test
- [x] All tests pass
- [x] [Reference or close any relevant issues](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)

## Additional details
*Benchmarking:* to give a ballpark check on the performance improvements, I ran 500 samples of `scipy.optimize.minimize()` optimizing the mechanical power for the WaveBot (basically mirroring part 1 of [Tutorial 1](https://github.com/SNL-WaterPower/WecOptTool/blob/3d9caf446706d2761d5a6c55f69af3c7096b718a/examples/tutorial_1_wavebot.ipynb)) using both the current [`main`](https://github.com/SNL-WaterPower/WecOptTool/tree/3d9caf446706d2761d5a6c55f69af3c7096b718a) branch of WecOptTool (which includes the sine component of the 2-point wave) and my [fork](https://github.com/michaelcdevin/WecOptTool/tree/5340c5b55a0d91e31fc9633e9ae0e3e0721a90af) (which does not). Note that this was run on my laptop with similar background processes, so this isn't a highly controlled test, but should give an idea of the performance improvement. Results of this are below:
Parameter | `main` | fork  |
|----|----|---- |
| Average objective function value | -101.1402 W | -101.1404 W |
| Average solve time | 14.91 seconds (σ=0.871) | 14.61 seconds (σ=1.072) |
| Average iterations to solve | 18.216 (σ=0.628) | 18.054 (σ=0.696) |
| Average function evaluations | 18.626 (σ=0.653) | 18.414 (σ=0.704) |

Pretty modest improvements, but certainly statistically significant given the sample size and standard deviations.
