### PR TITLE
Add skips to unit tests for when `geom` module isn't installed

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -56,8 +56,16 @@ def pi_controller_pto():
 @pytest.fixture(scope="module")
 def fb():
     """Capytaine FloatingBody object"""
+    try:
+        import wot.geom as geom
+    except ImportError:
+        pytest.skip(
+            'Skipping integration tests due to missing optional geometry ' +
+            'dependencies. Run `pip install wecopttool[geometry]` to run ' +
+            'these tests.'
+            )
     mesh_size_factor = 0.5
-    wb = wot.geom.WaveBot()
+    wb = geom.WaveBot()
     mesh = wb.mesh(mesh_size_factor)
 
     fb = cpy.FloatingBody.from_meshio(mesh, name="WaveBot")


### PR DESCRIPTION
## Description
All the tests in `test_integration.py` are dependent on having the `wecopttool.geom` module installed. If a user does not have `meshio`, `gmsh`, and `pygmsh` installed (as done via `pip install wecopttool[geometry]`), the `wecopttool.geom` module is not installed, which caused all the `test_integration.py` tests to error out. This PR adds a skip to all the tests in `test_integration.py` if `wecopttool.geom` is not installed to eliminate the `pytest` errors. Fixes #179.

## Type of PR
- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Other: (specify)

## Checklist for PR
- [x] Authors read the [contribution guidelines](https://github.com/SNL-WaterPower/WecOptTool/blob/main/.github/CONTRIBUTING.md)
- [x] The pull request is from an issue branch (not main) on *your* fork, to the [main branch in WecOptTool](https://github.com/SNL-WaterPower/WecOptTool).
- [x] The authors have given the admins edit access
- [x] All changes adhere to the style guide including PEP8, Docstrings, and Type Hints.
- [x] Modified the documentation if applicable
- [x] Modified or added a new test
- [x] All tests pass
- [x] [Reference or close any relevant issues](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)