### PR TITLE
Documentation build corrections and cleanup

### DIFF
--- a/docs/build_docs.py
+++ b/docs/build_docs.py
@@ -32,8 +32,19 @@ def html():
     
     app.build()
 
+def cleanup():
+    index_file = os.path.join(html_dir, 'index.html')
+    with open(index_file, 'r', encoding='utf-8') as f:
+        data = f.read()
+
+    with open(index_file, 'w', encoding='utf-8') as f:
+        data2 = re.sub(
+            '\<section id="package"\>.*?\</section\>',
+            '', data, flags=re.DOTALL)
+        f.write(data2)
 
 if __name__ == '__main__':
     source.make_theory_animations
-    # linkcheck()
+    linkcheck()
     html()
+    cleanup()

--- a/docs/build_docs.py
+++ b/docs/build_docs.py
@@ -1,5 +1,5 @@
 import os
-from shutil import rmtree
+import re
 import source.make_theory_animations
 from sphinx.application import Sphinx
 
@@ -7,15 +7,15 @@ docs_dir = os.path.dirname(os.path.abspath(__file__))
 source_dir = os.path.join(docs_dir, 'source')
 conf_dir = source_dir
 build_dir = os.path.join(docs_dir, '_build')
-doctree_dir = os.path.join(build_dir, '.doctrees')
-example_dir = os.path.join(source_dir, '_examples')
-api_dir = os.path.join(source_dir, 'api_docs')
+linkcheck_dir = os.path.join(build_dir, 'linkcheck')
+html_dir = os.path.join(build_dir, 'html')
+doctree_dir = os.path.join(build_dir, 'doctrees')
 
 
 def linkcheck():
     app = Sphinx(source_dir,
                  conf_dir,
-                 build_dir,
+                 linkcheck_dir,
                  doctree_dir,
                  'linkcheck',
                  warningiserror=True)
@@ -25,7 +25,7 @@ def linkcheck():
 def html():
     app = Sphinx(source_dir,
                  conf_dir,
-                 build_dir,
+                 html_dir,
                  doctree_dir,
                  'html',
                  warningiserror=True)
@@ -35,5 +35,5 @@ def html():
 
 if __name__ == '__main__':
     source.make_theory_animations
-    linkcheck()
+    # linkcheck()
     html()

--- a/docs/clean_docs.py
+++ b/docs/clean_docs.py
@@ -2,13 +2,15 @@ import os
 from shutil import rmtree
 
 docs_dir = os.path.dirname(os.path.abspath(__file__))
+build_dir = os.path.join(docs_dir, '_build')
 source_dir = os.path.join(docs_dir, 'source')
 example_dir = os.path.join(source_dir, '_examples')
 api_dir = os.path.join(source_dir, 'api_docs')
 
 def clean():
-    rmtree(example_dir)
-    rmtree(api_dir)
+    rmtree(example_dir, ignore_errors=True)
+    rmtree(api_dir, ignore_errors=True)
+    rmtree(build_dir, ignore_errors=True)
 
 if __name__ == '__main__':
     clean()

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -60,6 +60,7 @@ suppress_warnings = ['autosectionlabel.*', # nbsphinx and austosectionlabel do n
 linkcheck_ignore = [
     'https://github.com/HIPS/autograd/blob/master/docs/tutorial.md#supported-and-unsupported-parts-of-numpyscipy',
     'https://doi.org/10.2172/1330189',
+    r'https://snl-waterpower.github.io/WecOptTool/.*'
 ]
 
 # -- References (BibTex) -----------------------------------------------------

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -19,7 +19,7 @@ sys.path.insert(0, code_root)
 # -- Project information -----------------------------------------------------
 project = 'WecOptTool'
 copyright = (
-    'Copyright 2020 National Technology & Engineering Solutions of Sandia, ' +
+    '2020 National Technology & Engineering Solutions of Sandia, ' +
     'LLC(NTESS).' +
     'Under the terms of Contract DE-NA0003525 with NTESS, the U.S. ' +
     'Government retains certain rights in this software.'


### PR DESCRIPTION
## Description
The changes made in #204 made it so the build files were being placed in the `docs/_build` folder, but should be in the `docs/_build/html` folder, as this was what was done before using the Makefile, and is where the release workflow [looks for files](https://github.com/SNL-WaterPower/WecOptTool/blob/main/.github/workflows/release.yml#L71). Fixes #209.

This also cleans up other related aspects of the new documentation site build scheme:
* [The final line of the old Makefile](https://github.com/SNL-WaterPower/WecOptTool/blob/42a27d882a48ff6870e5600dca1263d577641a36/docs/Makefile#L24) is now being replicated
* Added a `linkcheck_ignore` line to have a better fix for #207
* Removed a redundant "copyright" to fix #195
* The `docs/clean_docs.py` file now cleans up more completely

## Type of PR
- [x] Bug fix
- [x] Documentation

## Checklist for PR
- [x] Authors read the [contribution guidelines](https://github.com/SNL-WaterPower/WecOptTool/blob/main/.github/CONTRIBUTING.md)
- [x] The pull request is from an issue branch (not main) on *your* fork, to the [main branch in WecOptTool](https://github.com/SNL-WaterPower/WecOptTool).
- [x] The authors have given the admins edit access
- [x] All changes adhere to the style guide including PEP8, Docstrings, and Type Hints.
- [x] Modified the documentation if applicable
- [x] Modified or added a new test
- [x] All tests pass
- [x] [Reference or close any relevant issues](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)