### PR TITLE
PTO Force bug fix

### DIFF
--- a/examples/tutorial_1_wavebot.ipynb
+++ b/examples/tutorial_1_wavebot.ipynb
@@ -295,7 +295,7 @@
    "outputs": [],
    "source": [
     "obj_fun = pto.mechanical_average_power\n",
-    "nstate_opt = 2*nfreq"
+    "nstate_opt = 2*nfreq-1"
    ]
   },
   {
@@ -777,7 +777,7 @@
     "\n",
     "    # Objective function\n",
     "    obj_fun = pto.average_power\n",
-    "    nstate_opt = 2*nfreq\n",
+    "    nstate_opt = 2*nfreq-1\n",
     "    \n",
     "    # Solve\n",
     "    scale_x_wec = 1e1  \n",
@@ -872,7 +872,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.8"
+   "version": "3.10.9"
   },
   "vscode": {
    "interpreter": {

--- a/examples/tutorial_2_AquaHarmonics.ipynb
+++ b/examples/tutorial_2_AquaHarmonics.ipynb
@@ -476,7 +476,7 @@
     "    {'type': 'ineq', 'fun': const_peak_torque_pto,},\n",
     "    {'type': 'ineq', 'fun': const_speed_pto,},\n",
     "    {'type': 'ineq', 'fun': const_power_pto,},\n",
-    "    {'type': 'eq', 'fun': zero_mean_pos},\n",
+    "    # {'type': 'eq', 'fun': zero_mean_pos},\n",
     "]"
    ]
   },
@@ -926,7 +926,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "wot_dev",
+   "display_name": "lupa",
    "language": "python",
    "name": "python3"
   },
@@ -944,7 +944,7 @@
   },
   "vscode": {
    "interpreter": {
-    "hash": "a3e13d9eb6391ec8c830b5b864d7e2cac256aef786c5e95ba02dc5258710976f"
+    "hash": "5f1b7498153de1ef790d85513ae6a6884367c8033d81f0adb6246852f852a267"
    }
   }
  },

--- a/examples/tutorial_2_AquaHarmonics.ipynb
+++ b/examples/tutorial_2_AquaHarmonics.ipynb
@@ -348,7 +348,7 @@
     "gear_ratio_generator = gear_ratios['R21']/radii['S3']\n",
     "kinematics = gear_ratio_generator*np.eye(ndof)\n",
     "controller = None\n",
-    "nstate_opt = 2*nfreq\n",
+    "nstate_opt = 2*nfreq-1\n",
     "pto_impedance = None\n",
     "pto = wot.pto.PTO(\n",
     "    ndof, kinematics, controller, pto_impedance, power_loss, name\n",
@@ -940,7 +940,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.8"
+   "version": "3.10.9"
   },
   "vscode": {
    "interpreter": {

--- a/wecopttool/pto.py
+++ b/wecopttool/pto.py
@@ -427,7 +427,7 @@ class PTO:
         waves: Optional[Dataset] = None,
         nsubsteps: Optional[int] = 1,
     ) -> tuple[ndarray, ndarray]:
-        """Calculate the power variables (flow q and effort e) time-series 
+        """Calculate the power variables (flow q and effort e) time-series
         in each PTO DOF for a given system state.
 
         Parameters
@@ -446,7 +446,7 @@ class PTO:
             A value of :python:`1` corresponds to the default step
             length.
         """
-        # convert q1 (PTO velocity), e1 (PTO force) 
+        # convert q1 (PTO velocity), e1 (PTO force)
         # to q2 (flow variable), e2 (effort variable)
         if self.impedance is not None:
             q1_td = self.velocity(wec, x_wec, x_opt, waves)
@@ -493,7 +493,7 @@ class PTO:
             A value of :python:`1` corresponds to the default step
             length.
         """
-        q2_td, e2_td = self.power_variables(wec, x_wec, 
+        q2_td, e2_td = self.power_variables(wec, x_wec,
                                             x_opt, waves, nsubsteps)
         # power
         power_out = q2_td * e2_td
@@ -566,8 +566,8 @@ class PTO:
         waves: Optional[Dataset] = None,
         nsubsteps: Optional[int] = 1,
     ) -> float:
-        """Calculate the transduced flow variable time-series in each PTO DOF 
-        for a given system state. Equals the PTO velocity if no impedance 
+        """Calculate the transduced flow variable time-series in each PTO DOF
+        for a given system state. Equals the PTO velocity if no impedance
         is defined.
 
         Examples for PTO impedance and corresponding flow variables:
@@ -579,7 +579,7 @@ class PTO:
         - Generator: winding impedance: flow = electric current
 
         - Drive-train and Generator combined: flow = electric current
-        
+
         Parameters
         ----------
         wec
@@ -596,9 +596,9 @@ class PTO:
             A value of :python:`1` corresponds to the default step
             length.
         """
-        q2_td, _ = self.power_variables(wec, x_wec, 
+        q2_td, _ = self.power_variables(wec, x_wec,
                                         x_opt, waves, nsubsteps)
-        return q2_td   
+        return q2_td
 
     def transduced_effort(self,
         wec: TWEC,
@@ -607,8 +607,8 @@ class PTO:
         waves: Optional[Dataset] = None,
         nsubsteps: Optional[int] = 1,
     ) -> float:
-        """Calculate the transduced flow variable time-series in each PTO DOF 
-        for a given system state. Equals the PTO force if no impedance 
+        """Calculate the transduced flow variable time-series in each PTO DOF
+        for a given system state. Equals the PTO force if no impedance
         is defined.
 
         Examples for PTO impedance and corresponding effort variables:
@@ -638,7 +638,7 @@ class PTO:
             length.
         """
         _, e2_td = self.power_variables(wec, x_wec, x_opt, waves, nsubsteps)
-        return e2_td  
+        return e2_td
 
     def post_process(self,
         wec: TWEC,
@@ -719,7 +719,7 @@ class PTO:
         # mechanical power
         mech_power_td = self.mechanical_power(wec, x_wec, x_opt, waves,
                                               nsubsteps)
-        mech_power_fd = wec.td_to_fd(mech_power_td[::nsubsteps])    
+        mech_power_fd = wec.td_to_fd(mech_power_td[::nsubsteps])
 
         pos_attr = {'long_name': 'Position', 'units': 'm or rad'}
         vel_attr = {'long_name': 'Velocity', 'units': 'm/s or rad/s'}
@@ -744,7 +744,7 @@ class PTO:
                 'acc': (['omega','dof'], acc_fd, acc_attr),
                 'force': (['omega','dof'], force_fd, force_attr),
                 'power': (['omega','dof'], power_fd, power_attr),
-                'mech_power': (['omega','dof'], 
+                'mech_power': (['omega','dof'],
                                 mech_power_fd, mech_power_attr)
             },
             coords={
@@ -770,7 +770,7 @@ class PTO:
                 'dof':('dof', self.names, dof_attr)},
             attrs={"time_created_utc": create_time}
             )
-        
+
         if self.impedance is not None:
         #transduced flow and effort variables
             q2_td, e2_td = self.power_variables(wec, x_wec, x_opt,
@@ -778,9 +778,9 @@ class PTO:
             q2_fd = wec.td_to_fd(q2_td[::nsubsteps])
             e2_fd = wec.td_to_fd(e2_td[::nsubsteps])
 
-            q2_attr = {'long_name': 'Transduced Flow', 
+            q2_attr = {'long_name': 'Transduced Flow',
                        'units': 'A or m^3/s or rad/s or m/s'}
-            e2_attr = {'long_name': 'Transduced Effort', 
+            e2_attr = {'long_name': 'Transduced Effort',
                        'units': 'V or N/m^2 or Nm or Ns'}
 
             results_td = results_td.assign({
@@ -881,7 +881,7 @@ def controller_unstructured(
         length.
     """
     x_opt = np.reshape(x_opt, (-1, pto.ndof), order='F')
-    tmat = pto._tmat(wec, nsubsteps)
+    tmat = pto._tmat(wec, nsubsteps)[:, 1:]
     return np.dot(tmat, x_opt)
 
 


### PR DESCRIPTION
## Description
Fixes #213. Removes the mean PTO force from the optimization variables for the unstructured controller

## Type of PR
- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Other: (specify)

## Checklist for PR
- [ ] Authors read the [contribution guidelines](https://github.com/SNL-WaterPower/WecOptTool/blob/main/.github/CONTRIBUTING.md)
- [ ] The pull request is from an issue branch (not main) on *your* fork, to the [main branch in WecOptTool](https://github.com/SNL-WaterPower/WecOptTool).
- [ ] The authors have given the admins edit access
- [ ] All changes adhere to the style guide including PEP8, Docstrings, and Type Hints.
- [ ] Modified the documentation if applicable
- [ ] Modified or added a new test
- [ ] All tests pass
- [ ] [Reference or close any relevant issues](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)

## Additional details

