### PR TITLE
Update unstructured controller to allow for extra optimization variables

### DIFF
--- a/wecopttool/pto.py
+++ b/wecopttool/pto.py
@@ -902,8 +902,8 @@ def controller_unstructured(
         A value of :python:`1` corresponds to the default step
         length.
     """
-    x_opt = np.reshape(x_opt, (-1, pto.ndof), order='F')
     tmat = pto._tmat(wec, nsubsteps)
+    x_opt = np.reshape(x_opt[:len(tmat[0])*pto.ndof], (-1, pto.ndof), order='F')
     return np.dot(tmat, x_opt)
 
 


### PR DESCRIPTION
## Description
This PR is intended to allow extra optimization variables to be used when using WecOptTool (issue #198) such as pto variables, etc. For the structured controllers, the force calculation already selects each gain individually, which means any extra variables on the end of x_opt simply don't affect the calculation. For the unstructured controller, the force is the product of x_opt and the time matrix, so the first N elements of x_opt can be selected where N is the number of columns in tmat. Any extra optimization variables are defined by increasing the value of the nstate_opt variable and then can be extracted from the end of x_opt to be used in forcing functions, constraints, etc. 

## Type of PR
- [ ] Bug fix
- [X] New feature
- [ ] Documentation
- [ ] Other: (specify)

## Checklist for PR
- [X] Authors read the [contribution guidelines](https://github.com/SNL-WaterPower/WecOptTool/blob/main/.github/CONTRIBUTING.md)
- [X] The pull request is from an issue branch (not main) on *your* fork, to the [main branch in WecOptTool](https://github.com/SNL-WaterPower/WecOptTool).
- [X] The authors have given the admins edit access
- [X] All changes adhere to the style guide including PEP8, Docstrings, and Type Hints.
- [ ] Modified the documentation if applicable
- [ ] Modified or added a new test
- [ ] All tests pass
- [ ] [Reference or close any relevant issues](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)

## Additional details
